### PR TITLE
fix: add missing chain id when storing session to local storage

### DIFF
--- a/packages/keychain/src/utils/controller.ts
+++ b/packages/keychain/src/utils/controller.ts
@@ -103,6 +103,7 @@ export default class Controller {
         maxFee,
         credentials,
         expiresAt: expiresAt.toString(),
+        chainId: this.account.chainId,
       },
     );
   }


### PR DESCRIPTION
The `get` function returns a `Session`:

https://github.com/cartridge-gg/controller/blob/357f1d5da778622b321214e257e73544134545e4/packages/keychain/src/utils/controller.ts#L116-L120

the `Session` type has a `chainId` field but it's being left out when being stored to local store.

https://github.com/cartridge-gg/controller/blob/357f1d5da778622b321214e257e73544134545e4/packages/controller/src/types.ts#L30-L39

Didn't seem to cause issue currently prob because we're using `this.account.chainId` in (in all the places where chain id matters) instead of the one stored in the `Session` object. 

