### PR TITLE
Redeploy counterfactual accounts

### DIFF
--- a/packages/keychain/src/components/Container/index.tsx
+++ b/packages/keychain/src/components/Container/index.tsx
@@ -44,7 +44,7 @@ export function Container({
           onClick={close}
         />
       )}
-      
+
       <Header chainId={chainId} onBack={onBack} hideAccount={hideAccount} />
 
       <VStack

--- a/packages/keychain/src/components/Container/index.tsx
+++ b/packages/keychain/src/components/Container/index.tsx
@@ -14,6 +14,7 @@ import { Header, HeaderProps } from "./Header";
 import { constants } from "starknet";
 import { CartridgeLogo, TimesIcon } from "@cartridge/ui";
 import { useConnection } from "hooks/connection";
+import { isIframe } from "components/connect/utils";
 
 export function Container({
   children,
@@ -29,19 +30,21 @@ export function Container({
 
   return (
     <Wrapper {...rest}>
-      <IconButton
-        aria-label="Close Keychain"
-        icon={<TimesIcon />}
-        position="absolute"
-        zIndex="9999999"
-        colorScheme="translucent"
-        size="sm"
-        h={8}
-        top={3}
-        left={3}
-        onClick={close}
-      />
-
+      {isIframe() && (
+        <IconButton
+          aria-label="Close Keychain"
+          icon={<TimesIcon />}
+          position="absolute"
+          zIndex="9999999"
+          colorScheme="translucent"
+          size="sm"
+          h={8}
+          top={3}
+          left={3}
+          onClick={close}
+        />
+      )}
+      
       <Header chainId={chainId} onBack={onBack} hideAccount={hideAccount} />
 
       <VStack

--- a/packages/keychain/src/components/Transaction.tsx
+++ b/packages/keychain/src/components/Transaction.tsx
@@ -6,7 +6,6 @@ import { StarkscanUrl } from "utils/url";
 import { CheckIcon, ExternalIcon, StarknetIcon, Loading } from "@cartridge/ui";
 import { useController } from "hooks/controller";
 import { useChainName } from "hooks/chain";
-import Account from "utils/account";
 
 export type TransactionState = "pending" | "success" | "error";
 
@@ -32,7 +31,6 @@ export function Transaction({
       let result: TransactionState = "pending";
       controller.account
         .waitForTransaction(hash, {
-          ...Account.waitForTransactionOptions,
           retryInterval: 8000,
         })
         .then(() => {

--- a/packages/keychain/src/components/connect/Login.tsx
+++ b/packages/keychain/src/components/connect/Login.tsx
@@ -90,7 +90,17 @@ export function Login({
 
       setIsLoading(false);
     },
-    [chainId, rpcUrl, origin, policies, expiresAt, isSlot, log],
+    [
+      chainId,
+      rpcUrl,
+      origin,
+      policies,
+      expiresAt,
+      mode,
+      log,
+      onSuccess,
+      setController,
+    ],
   );
 
   return (

--- a/packages/keychain/src/components/connect/Signup.tsx
+++ b/packages/keychain/src/components/connect/Signup.tsx
@@ -15,7 +15,6 @@ import {
 import { useCallback, useEffect, useState } from "react";
 import { DeployAccountDocument, useAccountQuery } from "generated/graphql";
 import Controller from "utils/controller";
-import { Status } from "utils/account";
 import { client } from "utils/graphql";
 import { PopupCenter } from "utils/url";
 import { FormValues, SignupProps } from "./types";
@@ -122,6 +121,12 @@ function Form({
       cacheTime: 10000000,
       refetchInterval: (data) => (!data ? 1000 : undefined),
       onSuccess: async (data) => {
+        // Deploy account
+        await client.request(DeployAccountDocument, {
+          id: values.username,
+          chainId: `starknet:${shortString.decodeShortString(chainId)}`,
+        });
+
         const {
           account: {
             credentials: {
@@ -140,16 +145,7 @@ function Form({
           credentialId,
         });
 
-        controller.account.status = Status.DEPLOYING;
-
-        await client.request(DeployAccountDocument, {
-          id: values.username,
-          chainId: `starknet:${shortString.decodeShortString(chainId)}`,
-        });
-
         controller.store();
-        await controller.account.sync();
-
         setController(controller);
 
         if (onSuccess) {

--- a/packages/keychain/src/utils/connection/execute.ts
+++ b/packages/keychain/src/utils/connection/execute.ts
@@ -37,7 +37,10 @@ export function executeFactory({
         });
       }
       const account = controller.account;
-      if (account.status === Status.DEPLOYING) {
+      if (
+        account.status === Status.COUNTERFACTUAL ||
+        account.status === Status.DEPLOYING
+      ) {
         return Promise.resolve({
           code: ResponseCodes.NOT_ALLOWED,
           message: "Account is deploying.",

--- a/packages/keychain/src/utils/controller.ts
+++ b/packages/keychain/src/utils/controller.ts
@@ -50,12 +50,19 @@ export default class Controller {
     this.rpcUrl = rpcUrl;
     this.publicKey = publicKey;
     this.credentialId = credentialId;
-    this.account = new Account(chainId, rpcUrl, address, this.signer, {
-      rpId: process.env.NEXT_PUBLIC_RP_ID,
-      origin: process.env.NEXT_PUBLIC_ORIGIN,
-      credentialId,
-      publicKey,
-    });
+    this.account = new Account(
+      chainId,
+      rpcUrl,
+      address,
+      username,
+      this.signer,
+      {
+        rpId: process.env.NEXT_PUBLIC_RP_ID,
+        origin: process.env.NEXT_PUBLIC_ORIGIN,
+        credentialId,
+        publicKey,
+      },
+    );
   }
 
   async getUser() {


### PR DESCRIPTION
This updates the account status logic to handle redeployment.

The init state is always `DEPLOYING`, it will try to grab deployment txn and receipt.
If success -> `DEPLOYED`, controller usable
If failure -> `COUNTERFACTUAL`, deployment failed for watever reason, frontend intercepts `execute` and request backend redeployment