### PR TITLE
Include Discord link on Slot failure page

### DIFF
--- a/packages/keychain/src/pages/slot/auth/failure.tsx
+++ b/packages/keychain/src/pages/slot/auth/failure.tsx
@@ -1,5 +1,7 @@
 import { Container, Banner } from "components/layout";
-import { AlertIcon } from "@cartridge/ui";
+import { AlertIcon, ExternalIcon } from "@cartridge/ui";
+import { Link, Text } from "@chakra-ui/react";
+import NextLink from "next/link"
 
 export default function Consent() {
   return (
@@ -7,7 +9,27 @@ export default function Consent() {
       <Banner
         icon={<AlertIcon boxSize={9} />}
         title="Uh-oh something went wrong"
-        description="If this problem persists swing by the Cartridge support channel on Discord"
+        description={
+          <>
+            If this problem persists swing by the Cartridge
+            <Text color="inherit">
+              support channel on{" "}
+              <Link
+                as={NextLink}
+                href="https://discord.gg/cartridge"
+                isExternal
+                color="link.blue"
+                display="inline-flex"
+                flexDir="row"
+                columnGap="0.1rem"
+                alignItems="center"
+              >
+                Discord
+                <ExternalIcon />
+              </Link>
+            </Text>
+          </>
+        }
       />
     </Container>
   );


### PR DESCRIPTION
<img width="631" alt="Screenshot 2024-06-08 at 4 24 20 AM" src="https://github.com/cartridge-gg/controller/assets/26515232/1c69287b-97c2-406c-a92e-53de003e6229">

i think tailwind is suppressing the default anchor underlining text decor. Not sure if that is the convention that Controller is using, because otherwise I think having the default link underlining behaviour on hover is good as it's a very common thing.