### PR TITLE
Fix popup being blocked on safari

### DIFF
--- a/examples/starknet-react-next/src/components/StarknetProvider.tsx
+++ b/examples/starknet-react-next/src/components/StarknetProvider.tsx
@@ -25,17 +25,7 @@ export function StarknetProvider({ children }: PropsWithChildren) {
   );
 }
 
-const url =
-  !process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL ||
-    process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL.split(".")[0] ===
-    "cartridge-starknet-react-next"
-    ? process.env.XFRAME_URL
-    : "https://" +
-    (process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL ?? "").replace(
-      "cartridge-starknet-react-next",
-      "keychain",
-    );
-
+const url = "https://keychain-git-fix-formik-popup.preview.cartridge.gg";
 const connectors = [
   new CartridgeConnector(
     [

--- a/examples/starknet-react-next/src/components/StarknetProvider.tsx
+++ b/examples/starknet-react-next/src/components/StarknetProvider.tsx
@@ -25,7 +25,17 @@ export function StarknetProvider({ children }: PropsWithChildren) {
   );
 }
 
-const url = "https://keychain-git-fix-formik-popup.preview.cartridge.gg";
+const url =
+  !process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL ||
+    process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL.split(".")[0] ===
+    "cartridge-starknet-react-next"
+    ? process.env.XFRAME_URL
+    : "https://" +
+    (process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL ?? "").replace(
+      "cartridge-starknet-react-next",
+      "keychain",
+    );
+
 const connectors = [
   new CartridgeConnector(
     [


### PR DESCRIPTION
This is a dumb issue... for some reason if we popup inside onSubmit handler of Formik, Safari will auto block it. onSubmit of `form` is fine but we lose formik context... So instead we do popup in onClick and then trigger submit.

I was trying to move us to `react-hook-form` but that's becoming a bigger refactor, so this is workaround for now.