### PR TITLE
account-sdk: include more context in the error type

### DIFF
--- a/packages/account_sdk/src/signers/mod.rs
+++ b/packages/account_sdk/src/signers/mod.rs
@@ -29,7 +29,7 @@ pub enum SignError {
     /// Represents an error when trying to perform contract invocation that is not part
     /// of a session's allowed methods.
     #[error(
-        "Not allowed to call method selector `{selector:#x}` on contract: `{contract_address:#x}`"
+        "Not allowed to call method selector `{selector:#x}` on contract `{contract_address:#x}`"
     )]
     SessionMethodNotAllowed {
         /// The method selector that was not allowed.

--- a/packages/account_sdk/src/signers/mod.rs
+++ b/packages/account_sdk/src/signers/mod.rs
@@ -16,14 +16,28 @@ use self::webauthn::DeviceError;
 pub enum SignError {
     #[error("Signer error: {0}")]
     Signer(EcdsaSignError),
+
     #[error("Device error: {0}")]
     Device(DeviceError),
+
     #[error("NonAsciiName error: {0}")]
     NonAsciiSessionNameError(#[from] NonAsciiNameError),
+
     #[error("NoAllowedSessionMethods error")]
     NoAllowedSessionMethods,
-    #[error("MethodNotAllowed error")]
-    SessionMethodNotAllowed,
+
+    /// Represents an error when trying to perform contract invocation that is not part
+    /// of a session's allowed methods.
+    #[error(
+        "Not allowed to call method selector `{selector:#x}` on contract: `{contract_address:#x}`"
+    )]
+    SessionMethodNotAllowed {
+        /// The method selector that was not allowed.
+        selector: FieldElement,
+        /// The contract address the method was called on.
+        contract_address: FieldElement,
+    },
+
     #[error("Invalid message provided: {0}")]
     InvalidMessageError(String),
 }


### PR DESCRIPTION
Include the contract address and method selector in the enum variant for `SessionMethodNotAllowed` error.

So we can get descriptive error message like this : 

```
Not allowed to call method selector `0x2268edf67b91950354fd1020241302474ef67970e8063160d48ee70c4e0da9e` on contract `0x4c204b4778aba2dff115adfc8d89d5bdd37a0c5da1378ed36ce30242e03ff75`
```