### PR TITLE
Disable click outside modal dismissal

### DIFF
--- a/packages/controller/src/modal.ts
+++ b/packages/controller/src/modal.ts
@@ -42,8 +42,6 @@ export const createModal = (src: string, onClose?: () => void) => {
     container.style.opacity = "0";
   };
 
-  container.onclick = () => close();
-
   resize(iframe);
   window.addEventListener("resize", () => resize(iframe));
 


### PR DESCRIPTION
We can also add a transparent layer in keychain to catch outside clicks instead. 