### PR TITLE
Account execute throws if response is not success

### DIFF
--- a/examples/starknet-react-next/src/components/DojoSpawnAndMove.tsx
+++ b/examples/starknet-react-next/src/components/DojoSpawnAndMove.tsx
@@ -46,9 +46,10 @@ export function DojoSpawnAndMove() {
           onClick={async () => {
             setTxnHash(undefined);
             setSubmitted(true);
-            const { transaction_hash } = await spawn();
-            setSubmitted(false);
-            setTxnHash(transaction_hash);
+            spawn()
+              .then(({ transaction_hash }) => setTxnHash(transaction_hash))
+              .catch((e) => console.error(e))
+              .finally(() => setSubmitted(false));
           }}
           disabled={submitted}
         >
@@ -58,9 +59,10 @@ export function DojoSpawnAndMove() {
           onClick={async () => {
             setTxnHash(undefined);
             setSubmitted(true);
-            const { transaction_hash } = await move();
-            setSubmitted(false);
-            setTxnHash(transaction_hash);
+            move()
+              .then(({ transaction_hash }) => setTxnHash(transaction_hash))
+              .catch((e) => console.error(e))
+              .finally(() => setSubmitted(false));
           }}
           disabled={submitted}
         >

--- a/examples/starknet-react-next/src/components/TransferEth.tsx
+++ b/examples/starknet-react-next/src/components/TransferEth.tsx
@@ -13,14 +13,16 @@ export const TransferEth = () => {
   const { account } = useAccount();
   const explorer = useExplorer();
   const [txnHash, setTxnHash] = useState<string>();
-  const execute005 = useCallback(async () => {
+
+  const execute = useCallback(async () => {
     if (!account) {
       return;
     }
     setSubmitted(true);
     setTxnHash(undefined);
-    const res = await account.execute(
-      [
+
+    account
+      .execute([
         {
           contractAddress: ETH_CONTRACT,
           entrypoint: "approve",
@@ -31,19 +33,10 @@ export const TransferEth = () => {
           entrypoint: "transfer",
           calldata: [account?.address, "0x11C37937E08000", "0x0"],
         },
-      ],
-      undefined,
-      {
-        chainId,
-      } as any,
-    );
-
-    setTxnHash(res.transaction_hash);
-    setSubmitted(false);
-    account
-      .waitForTransaction(res.transaction_hash)
-      .catch((err) => console.error(err))
-      .finally(() => console.log("done"));
+      ])
+      .then(({ transaction_hash }) => setTxnHash(transaction_hash))
+      .catch((e) => console.error(e))
+      .finally(() => setSubmitted(false));
   }, [account, chainId]);
 
   if (!account) {
@@ -55,7 +48,7 @@ export const TransferEth = () => {
       <h2>Transfer Eth</h2>
       <p>Address: {ETH_CONTRACT}</p>
 
-      <button onClick={() => execute005()} disabled={submitted}>
+      <button onClick={() => execute()} disabled={submitted}>
         Transfer 0.005 ETH to self
       </button>
       {txnHash && (

--- a/packages/controller/src/device.ts
+++ b/packages/controller/src/device.ts
@@ -113,16 +113,12 @@ class DeviceAccount extends Account {
       );
       this.modal.close();
 
-      if (
-        res.code !== ResponseCodes.SUCCESS &&
-        res.code !== ResponseCodes.CANCELED
-      ) {
-        throw new Error(res.message);
+      if (res.code !== ResponseCodes.SUCCESS) {
+        return Promise.reject(res.message);
       }
 
       return res as InvokeFunctionResponse;
     } catch (e) {
-      console.error(e);
       throw e;
     }
   }

--- a/packages/keychain/src/components/Execute/index.tsx
+++ b/packages/keychain/src/components/Execute/index.tsx
@@ -88,7 +88,6 @@ export function Execute() {
         setFees({ base: fees.overall_fee, max: fees.suggestedMaxFee });
       })
       .catch((e) => {
-        console.error(e);
         setError(e);
       });
   }, [account, controller, setError, setFees, calls, chainId, ctx]);

--- a/packages/keychain/src/hooks/connection.tsx
+++ b/packages/keychain/src/hooks/connection.tsx
@@ -54,7 +54,7 @@ export function ConnectionProvider({ children }: PropsWithChildren) {
     try {
       context.resolve({
         code: ResponseCodes.CANCELED,
-        message: "User closed modal",
+        message: "User aborted",
       });
       await parent.close();
     } catch (e) {


### PR DESCRIPTION
Account execute throws error if user cancels / rejects transaction. This is consistent with other wallets. 