### PR TITLE
Execute prompt uses webauthn insteaf of session

### DIFF
--- a/packages/keychain/src/components/Execute/index.tsx
+++ b/packages/keychain/src/components/Execute/index.tsx
@@ -17,7 +17,8 @@ import { Policies } from "Policies";
 import { Fees } from "./Fees";
 import { ExecuteCtx } from "utils/connection";
 import { TransferAmountExceedsBalance } from "errors";
-import { ESTIMATE_FEE_MULTIPLIER } from "utils/connection/execute";
+import { ETH_MIN_PREFUND } from "utils/token";
+import { num } from "starknet";
 
 export const CONTRACT_ETH =
   "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7";
@@ -112,20 +113,14 @@ export function Execute() {
 
   const onSubmit = useCallback(async () => {
     setLoading(true);
-    const session = controller.session(ctx.origin);
 
-    const { overall_fee } = await account.cartridge.estimateInvokeFee(
-      calls,
-      session,
-      ESTIMATE_FEE_MULTIPLIER,
-    );
-
+    // TODO: calculate webauthn validation cost separately
+    const maxFee = num.toHex(ctx.transactionsDetail?.maxFee || ETH_MIN_PREFUND);
     const { transaction_hash } = await account.execute(
       calls,
       {
-        maxFee: overall_fee,
+        maxFee,
       },
-      session,
     );
     ctx.resolve({
       transaction_hash,


### PR DESCRIPTION
If dapp doesn't include a method in policy then we'll prompt for execution, flow will be webauthn instead of session. However, for webauthn to have accurate estimated fees validation can't be skipped, this forces webauthn to prompt twice - once for estimate fee and then for actual invoke txn. 

Hardcoding the maxfee for webauthn flow for now. Proper solution is to calculate webauthn validation cost separately and add it to estimated fee with skipped validation. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated fee calculation logic in the `Execute` component to use `ETH_MIN_PREFUND` for more accurate transaction fee estimation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->