### PR TITLE
Probe sets rpc and chainId

### DIFF
--- a/packages/controller/src/index.ts
+++ b/packages/controller/src/index.ts
@@ -123,7 +123,7 @@ class Controller {
     }
 
     try {
-      const res = await this.keychain.probe();
+      const res = await this.keychain.probe(this.rpc.toString());
       if (res.code !== ResponseCodes.SUCCESS) {
         return;
       }

--- a/packages/controller/src/types.ts
+++ b/packages/controller/src/types.ts
@@ -57,11 +57,10 @@ export type ExecuteReply = InvokeFunctionResponse & {
 export type ProbeReply = {
   code: ResponseCodes.SUCCESS;
   address: string;
-  policies: Policy[];
 };
 
 export interface Keychain {
-  probe(): Promise<ProbeReply | ConnectError>;
+  probe(rpcUrl?: string): Promise<ProbeReply | ConnectError>;
   connect(
     policies: Policy[],
     rpcUrl: string,

--- a/packages/keychain/src/utils/connection/probe.ts
+++ b/packages/keychain/src/utils/connection/probe.ts
@@ -1,13 +1,17 @@
 import { ProbeReply, ResponseCodes } from "@cartridge/controller";
 import Controller from "utils/controller";
 
-export function probe(controller: Controller, origin: string) {
-  return (): ProbeReply => {
-    const session = controller.session(origin);
-    return {
+export function probe(controller: Controller, _origin: string) {
+  return (rpcUrl?: string): Promise<ProbeReply> => {
+    if (rpcUrl && controller.rpcUrl != rpcUrl) {
+      return Promise.reject({
+        code: ResponseCodes.NOT_CONNECTED,
+      });
+    }
+
+    return Promise.resolve({
       code: ResponseCodes.SUCCESS,
       address: controller.address,
-      policies: session?.policies || [],
-    };
+    });
   };
 }


### PR DESCRIPTION
Fixes controller using the wrong RPC when loaded on subdomain of a dapp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated RPC endpoint in StarknetProvider to use Sepolia network, enhancing compatibility with the latest network environments.
  - Simplified device account execution logic to ensure consistent initialization of transaction details.
  - Refined controller interactions with keychain for more straightforward policy and RPC management.

- **Refactor**
  - Removed error state handling across multiple components to streamline logic and improve user experience.
  - Adjusted connection utilities to enhance parameter handling and improve maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->