### PR TITLE
Show create session message only when some policies exist

### DIFF
--- a/packages/keychain/src/components/layout/Footer/index.tsx
+++ b/packages/keychain/src/components/layout/Footer/index.tsx
@@ -92,11 +92,13 @@ export function Footer({
           onClick={footer.onToggle}
           _hover={{ cursor: "pointer" }}
         >
-          <TransactionSummary
-            isSlot={isSlot}
-            createSession={createSession}
-            hostname={hostname}
-          />
+          {!!policies.length && (
+            <TransactionSummary
+              isSlot={isSlot}
+              createSession={createSession}
+              hostname={hostname}
+            />
+          )}
 
           <Spacer />
 


### PR DESCRIPTION
`/login` was showing expandable footer with create session key message even without any policies provided. This PR is to fix it.