### PR TITLE
Remove account deployment on slot auth

### DIFF
--- a/packages/keychain/src/pages/slot/session/index.tsx
+++ b/packages/keychain/src/pages/slot/session/index.tsx
@@ -9,7 +9,6 @@ import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
 import { PageLoading } from "components/Loading";
 import dynamic from "next/dynamic";
-import { useDeploy } from "hooks/deploy";
 
 type SessionQueryParams = Record<string, string> & {
   callback_uri: string;
@@ -25,7 +24,6 @@ function CreateSession() {
 
   const { controller, setController, policies, origin, chainId, rpcUrl } =
     useConnection();
-  const { deployRequest } = useDeploy();
 
   // Fetching account status for displaying the loading screen
   const [isFetching, setIsFetching] = useState(true);
@@ -52,9 +50,6 @@ function CreateSession() {
         method: "POST",
       })
         .then(async (res) => {
-          // request deployment to ensure account exists on chain
-          await deployRequest(controller.username);
-
           return res.status === 200
             ? router.replace(`/slot/auth/success`)
             : new Promise((_, reject) => reject(res));
@@ -64,7 +59,7 @@ function CreateSession() {
           router.replace(`/slot/auth/failure`);
         });
     },
-    [router, queries.callback_uri, controller.username, deployRequest],
+    [router, queries.callback_uri, controller.username],
   );
 
   // Handler when user clicks the Create button


### PR DESCRIPTION
`sozo` requests account deployment if not found so this is not needed.