### PR TITLE
Ignore sourcemap warning with vite

### DIFF
--- a/packages/profile/vite.config.ts
+++ b/packages/profile/vite.config.ts
@@ -13,4 +13,17 @@ export default defineConfig({
       "@": "/src",
     },
   },
+  // Ref: https://github.com/vitejs/vite/issues/15012#issuecomment-1948550039
+  build: {
+    sourcemap: true,
+    rollupOptions: {
+      onwarn(warning, defaultHandler) {
+        if (warning.code === "SOURCEMAP_ERROR") {
+          return;
+        }
+
+        defaultHandler(warning);
+      },
+    },
+  },
 });


### PR DESCRIPTION
Vite 5 sometimes throws these warning and task fails on CI. This PR is to suppress the warning for now.

```
@cartridge/profile:build: ../ui-next/dist/components/primitives/drawer.jsx (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
```