### PR TITLE
Collapsable login/signup error

### DIFF
--- a/packages/keychain/src/components/ErrorAlert.tsx
+++ b/packages/keychain/src/components/ErrorAlert.tsx
@@ -34,12 +34,14 @@ export function ErrorAlert({
   description,
   variant = "error",
   isExpanded = false,
+  allowToggle = false,
   copyText,
 }: {
   title: string;
   description?: string | ReactElement;
   variant?: string;
   isExpanded?: boolean;
+  allowToggle?: boolean;
   copyText?: string;
 }) {
   const [copied, setCopied] = useState(false);
@@ -55,7 +57,7 @@ export function ErrorAlert({
   return (
     <Accordion
       w="full"
-      allowToggle={!isExpanded}
+      allowToggle={!isExpanded || allowToggle}
       defaultIndex={isExpanded ? [0] : undefined}
       variant={variant}
       color="solid.bg"
@@ -64,7 +66,9 @@ export function ErrorAlert({
       <AccordionItem position="relative">
         {({ isExpanded: itemExpanded }) => (
           <>
-            <AccordionButton disabled={!description || isExpanded}>
+            <AccordionButton
+              disabled={!description || (isExpanded && !allowToggle)}
+            >
               <HStack>
                 {(() => {
                   switch (variant) {
@@ -88,7 +92,7 @@ export function ErrorAlert({
 
               <Spacer />
 
-              {description && !isExpanded && (
+              {description && (!isExpanded || allowToggle) && (
                 <HStack>
                   <Box
                     as={motion.div}

--- a/packages/keychain/src/components/connect/Login.tsx
+++ b/packages/keychain/src/components/connect/Login.tsx
@@ -109,6 +109,7 @@ function Form({
     mode,
     onSuccess,
     setController,
+    isSlot,
   ]);
 
   useEffect(() => {
@@ -157,6 +158,7 @@ function Form({
                 : error.message
             }
             isExpanded
+            allowToggle
           />
         )}
         <Button

--- a/packages/keychain/src/components/connect/Signup.tsx
+++ b/packages/keychain/src/components/connect/Signup.tsx
@@ -224,6 +224,7 @@ export function Signup({
                   : error.message
               }
               isExpanded
+              allowToggle
             />
           )}
 


### PR DESCRIPTION
close #686 

This fix still shows the login/signup error expanded when error is thrown.
But now the error has collapsable button so user can close it and see the username input.

<img width="464" alt="Screenshot 2024-09-11 at 16 31 38" src="https://github.com/user-attachments/assets/ebaa31b7-d52f-4089-a1d7-ce7f3345021c">
