### PR TITLE
Relax `async-trait` version to `0.1.80`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ account_sdk = { path = "packages/account_sdk" }
 account-wasm = { path = "packages/account-wasm" }
 
 anyhow = "1"
-async-trait = "0.1.82"
+async-trait = "0.1.80"
 base64 = "0.22"
 cairo-lang-starknet = "2.4.0"
 coset = { version = "0.3.4", features = ["std"] }


### PR DESCRIPTION
its causing dependencies version error when trying to use `account_sdk` as a dependency for other crates