### PR TITLE
fix(account-wasm): `JsFelt` de/serialization

### DIFF
--- a/packages/account-wasm/src/types/mod.rs
+++ b/packages/account-wasm/src/types/mod.rs
@@ -1,6 +1,7 @@
+use std::str::FromStr;
+
 use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
-use starknet::core::{serde::unsigned_field_element::UfeHex, utils::NonAsciiNameError};
+use starknet::core::utils::NonAsciiNameError;
 use starknet_types_core::felt::{Felt, FromStrError};
 use tsify_next::Tsify;
 
@@ -11,10 +12,9 @@ pub(crate) mod outside_execution;
 pub(crate) mod policy;
 pub(crate) mod session;
 
-#[serde_as]
 #[derive(Tsify, Serialize, Deserialize, Debug, Clone)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
-pub struct JsFelt(#[serde_as(as = "UfeHex")] pub Felt);
+pub struct JsFelt(#[serde(deserialize_with = "deserialize_felt")] pub Felt);
 
 #[derive(Tsify, Serialize, Deserialize, Debug, Clone)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
@@ -30,4 +30,52 @@ pub enum EncodingError {
 
     #[error("Serialization error: {0}")]
     Serialization(#[from] serde_wasm_bindgen::Error),
+}
+
+// need this in order to be able to deserialize from BOTH decimal and hex (0x-prefixed)e string.
+// the default Deserialize implementation of Felt only supports deserializing from hex strings.
+fn deserialize_felt<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<Felt, D::Error> {
+    let s = String::deserialize(deserializer)?;
+    Felt::from_str(&s).map_err(serde::de::Error::custom)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasm_bindgen::JsValue;
+    use wasm_bindgen_test::*;
+
+    #[wasm_bindgen_test]
+    fn test_jsfelt_serialization() {
+        let hex_str = "0x1309e973a3ec4c86dd679a455317ffdaa64e1e86d39f0b420";
+
+        let jsstr = JsValue::from_str(hex_str);
+        let jsfelt: JsFelt = serde_wasm_bindgen::from_value(jsstr).unwrap();
+
+        let str = serde_wasm_bindgen::to_value(&jsfelt).unwrap();
+        assert_eq!(hex_str, str.as_string().unwrap());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_jsfelt_deserialization() {
+        // --- test with hex string ---
+
+        let hex_str = "0x1309e973a3ec4c86dd679a455317ffdaa64e1e86d39f0b420";
+
+        let jsstr = JsValue::from_str(hex_str);
+        let deserialized: JsFelt = serde_wasm_bindgen::from_value(jsstr).unwrap();
+
+        let expected_felt = Felt::from_str(hex_str).unwrap();
+        assert_eq!(expected_felt, deserialized.0);
+
+        // --- test with decimal string ---
+
+        let dec_str = "1337";
+
+        let jsstr = JsValue::from_str(dec_str);
+        let deserialized: JsFelt = serde_wasm_bindgen::from_value(jsstr).unwrap();
+
+        let expected_felt = Felt::from_str(dec_str).unwrap();
+        assert_eq!(expected_felt, deserialized.0);
+    }
 }

--- a/packages/account-wasm/src/types/mod.rs
+++ b/packages/account-wasm/src/types/mod.rs
@@ -53,7 +53,7 @@ mod tests {
         let jsfelt: JsFelt = serde_wasm_bindgen::from_value(jsstr).unwrap();
 
         let str = serde_wasm_bindgen::to_value(&jsfelt).unwrap();
-        assert_eq!(hex_str, str.as_string().unwrap());
+        assert_eq!(hex_str, str.as_string().unwrap(), "Serialize as hex string");
     }
 
     #[wasm_bindgen_test]

--- a/packages/account-wasm/src/types/mod.rs
+++ b/packages/account-wasm/src/types/mod.rs
@@ -32,7 +32,7 @@ pub enum EncodingError {
     Serialization(#[from] serde_wasm_bindgen::Error),
 }
 
-// need this in order to be able to deserialize from BOTH decimal and hex (0x-prefixed)e string.
+// need this in order to be able to deserialize from BOTH decimal and hex (0x-prefixed) string.
 // the default Deserialize implementation of Felt only supports deserializing from hex strings.
 fn deserialize_felt<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<Felt, D::Error> {
     let s = String::deserialize(deserializer)?;


### PR DESCRIPTION
`UfeHex` deserializer treat all string as hex string... meaning from the deserialization perspective from string -> `JsFelt`, `0x111 == 111`