### PR TITLE
Add alias assignment for Vercel preview deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,13 +177,13 @@ jobs:
         run: pnpm vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
       - name: Build Project Artifacts (Preview)
         if: github.ref != 'refs/heads/main'
-        run: pnpm vercel build --token=${{ secrets.VERCEL_TOKEN }} --build-env NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL=keychain-${{ github.sha }}.preview.cartridge.gg --env NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL=keychain-${{ github.sha }}.preview.cartridge.gg
+        run: pnpm vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - name: Build Project Artifacts (Production)
         if: github.ref == 'refs/heads/main'
         run: pnpm vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy to Vercel (Preview)
         if: github.ref != 'refs/heads/main'
-        run: pnpm vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+        run: pnpm vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} --env NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL=keychain-${{ github.sha }}.preview.cartridge.gg
       - name: Deploy to Vercel (Production)
         if: github.ref == 'refs/heads/main'
         run: pnpm vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,10 +57,16 @@ jobs:
         run: pnpm vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy to Vercel (Preview)
         if: github.ref != 'refs/heads/main'
-        run: pnpm vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+        run: echo "url=$(pnpm vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})" > "$GITHUB_OUTPUT"
+        id: deploy
       - name: Deploy to Vercel (Production)
         if: github.ref == 'refs/heads/main'
         run: pnpm vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Assign Alias
+        if: github.ref != 'refs/heads/main'
+        run: |
+          pnpm vercel switch cartridge --token=${{ secrets.VERCEL_TOKEN }}
+          pnpm vercel alias set ${{ steps.deploy.outputs.url }} ${{ github.sha }}.preview.cartridge.gg --token=${{ secrets.VERCEL_TOKEN }}
 
   keychain-storybook:
     runs-on: ubuntu-latest
@@ -111,10 +117,16 @@ jobs:
         run: pnpm vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy to Vercel (Preview)
         if: github.ref != 'refs/heads/main'
-        run: pnpm vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+        run: echo "url=$(pnpm vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})" > "$GITHUB_OUTPUT"
+        id: deploy
       - name: Deploy to Vercel (Production)
         if: github.ref == 'refs/heads/main'
         run: pnpm vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Assign Alias
+        if: github.ref != 'refs/heads/main'
+        run: |
+          pnpm vercel switch cartridge --token=${{ secrets.VERCEL_TOKEN }}
+          pnpm vercel alias set ${{ steps.deploy.outputs.url }} ${{ github.sha }}.preview.cartridge.gg --token=${{ secrets.VERCEL_TOKEN }}
 
   cartridge-starknet-react-next:
     runs-on: ubuntu-latest
@@ -160,6 +172,8 @@ jobs:
       - name: Build Project Artifacts (Preview)
         if: github.ref != 'refs/heads/main'
         run: pnpm vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          NEXT_PUBLIC_DEPLOYMENT_URL: ${{ github.sha }}.preview.cartridge.gg
       - name: Build Project Artifacts (Production)
         if: github.ref == 'refs/heads/main'
         run: pnpm vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -169,7 +169,7 @@ jobs:
         if: github.ref != 'refs/heads/main'
         run: pnpm vercel build --token=${{ secrets.VERCEL_TOKEN }}
         env:
-          NEXT_PUBLIC_DEPLOYMENT_URL: ${{ github.sha }}.preview.cartridge.gg
+          NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL: ${{ github.sha }}.preview.cartridge.gg
       - name: Build Project Artifacts (Production)
         if: github.ref == 'refs/heads/main'
         run: pnpm vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -183,7 +183,7 @@ jobs:
         run: pnpm vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy to Vercel (Preview)
         if: github.ref != 'refs/heads/main'
-        run: pnpm vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} --env NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL=keychain-${{ github.sha }}.preview.cartridge.gg
+        run: pnpm vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} --env NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL=keychain-${{ github.sha }}.preview.cartridge.gg --build-env NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL=keychain-${{ github.sha }}.preview.cartridge.gg
       - name: Deploy to Vercel (Production)
         if: github.ref == 'refs/heads/main'
         run: pnpm vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,9 +62,12 @@ jobs:
       - name: Deploy to Vercel (Production)
         if: github.ref == 'refs/heads/main'
         run: pnpm vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Set outputs
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Assign Alias
         if: github.ref != 'refs/heads/main'
-        run: pnpm vercel alias set ${{ steps.deploy.outputs.url }} keychain-${{ github.sha }}.preview.cartridge.gg --scope=cartridge --token=${{ secrets.VERCEL_TOKEN }}
+        run: pnpm vercel alias set ${{ steps.deploy.outputs.url }} keychain-${{ steps.vars.outputs.sha_short }}.preview.cartridge.gg --scope=cartridge --token=${{ secrets.VERCEL_TOKEN }}
 
   keychain-storybook:
     runs-on: ubuntu-latest
@@ -120,9 +123,12 @@ jobs:
       - name: Deploy to Vercel (Production)
         if: github.ref == 'refs/heads/main'
         run: pnpm vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Set outputs
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Assign Alias
         if: github.ref != 'refs/heads/main'
-        run: pnpm vercel alias set ${{ steps.deploy.outputs.url }} keychain-storybook-${{ github.sha }}.preview.cartridge.gg --scope=cartridge --token=${{ secrets.VERCEL_TOKEN }}
+        run: pnpm vercel alias set ${{ steps.deploy.outputs.url }} keychain-${{ steps.vars.outputs.sha_short }}.preview.cartridge.gg --scope=cartridge --token=${{ secrets.VERCEL_TOKEN }}
 
   cartridge-starknet-react-next:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,13 +177,15 @@ jobs:
         run: pnpm vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
       - name: Build Project Artifacts (Preview)
         if: github.ref != 'refs/heads/main'
-        run: pnpm vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        run: |
+          echo "NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL=keychain-${{ github.sha }}.preview.cartridge.gg" >> ./examples/starknet-react-next/.env.local
+          pnpm vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - name: Build Project Artifacts (Production)
         if: github.ref == 'refs/heads/main'
         run: pnpm vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy to Vercel (Preview)
         if: github.ref != 'refs/heads/main'
-        run: pnpm vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} --env NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL=keychain-${{ github.sha }}.preview.cartridge.gg --build-env NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL=keychain-${{ github.sha }}.preview.cartridge.gg
+        run: pnpm vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy to Vercel (Production)
         if: github.ref == 'refs/heads/main'
         run: pnpm vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
         run: pnpm vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Assign Alias
         if: github.ref != 'refs/heads/main'
-        run: pnpm vercel alias set ${{ steps.deploy.outputs.url }} ${{ github.sha }}.preview.cartridge.gg --scope=cartridge --token=${{ secrets.VERCEL_TOKEN }}
+        run: pnpm vercel alias set ${{ steps.deploy.outputs.url }} keychain-${{ github.sha }}.preview.cartridge.gg --scope=cartridge --token=${{ secrets.VERCEL_TOKEN }}
 
   keychain-storybook:
     runs-on: ubuntu-latest
@@ -122,7 +122,7 @@ jobs:
         run: pnpm vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Assign Alias
         if: github.ref != 'refs/heads/main'
-        run: pnpm vercel alias set ${{ steps.deploy.outputs.url }} ${{ github.sha }}.preview.cartridge.gg --scope=cartridge --token=${{ secrets.VERCEL_TOKEN }}
+        run: pnpm vercel alias set ${{ steps.deploy.outputs.url }} keychain-storybook-${{ github.sha }}.preview.cartridge.gg --scope=cartridge --token=${{ secrets.VERCEL_TOKEN }}
 
   cartridge-starknet-react-next:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,9 +177,7 @@ jobs:
         run: pnpm vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
       - name: Build Project Artifacts (Preview)
         if: github.ref != 'refs/heads/main'
-        run: pnpm vercel build --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL: ${{ github.sha }}.preview.cartridge.gg
+        run: pnpm vercel build --token=${{ secrets.VERCEL_TOKEN }} --build-env NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL=keychain-${{ github.sha }}.preview.cartridge.gg --env NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL=keychain-${{ github.sha }}.preview.cartridge.gg
       - name: Build Project Artifacts (Production)
         if: github.ref == 'refs/heads/main'
         run: pnpm vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,9 +64,7 @@ jobs:
         run: pnpm vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Assign Alias
         if: github.ref != 'refs/heads/main'
-        run: |
-          pnpm vercel switch cartridge --token=${{ secrets.VERCEL_TOKEN }}
-          pnpm vercel alias set ${{ steps.deploy.outputs.url }} ${{ github.sha }}.preview.cartridge.gg --token=${{ secrets.VERCEL_TOKEN }}
+        run: pnpm vercel alias set ${{ steps.deploy.outputs.url }} ${{ github.sha }}.preview.cartridge.gg --scope=cartridge --token=${{ secrets.VERCEL_TOKEN }}
 
   keychain-storybook:
     runs-on: ubuntu-latest
@@ -124,9 +122,7 @@ jobs:
         run: pnpm vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Assign Alias
         if: github.ref != 'refs/heads/main'
-        run: |
-          pnpm vercel switch cartridge --token=${{ secrets.VERCEL_TOKEN }}
-          pnpm vercel alias set ${{ steps.deploy.outputs.url }} ${{ github.sha }}.preview.cartridge.gg --token=${{ secrets.VERCEL_TOKEN }}
+        run: pnpm vercel alias set ${{ steps.deploy.outputs.url }} ${{ github.sha }}.preview.cartridge.gg --scope=cartridge --token=${{ secrets.VERCEL_TOKEN }}
 
   cartridge-starknet-react-next:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Build Project Artifacts (Preview)
         if: github.ref != 'refs/heads/main'
         run: |
-          echo "NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL=keychain-${{ github.sha }}.preview.cartridge.gg" >> ./examples/starknet-react-next/.env.local
+          echo "NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL=https://keychain-${{ github.sha }}.preview.cartridge.gg" >> ./examples/starknet-react-next/.env.local
           pnpm vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - name: Build Project Artifacts (Production)
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -175,10 +175,15 @@ jobs:
       - name: Pull Vercel Environment Information (Production)
         if: github.ref == 'refs/heads/main'
         run: pnpm vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Set outputs
+        id: vars
+        run: |
+          git config --global --add safe.directory '*'
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Build Project Artifacts (Preview)
         if: github.ref != 'refs/heads/main'
         run: |
-          echo "NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL=https://keychain-${{ github.sha }}.preview.cartridge.gg" >> ./examples/starknet-react-next/.env.local
+          echo "NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL=https://keychain-${{ steps.vars.outputs.sha_short }}.preview.cartridge.gg" >> ./examples/starknet-react-next/.env.local
           pnpm vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - name: Build Project Artifacts (Production)
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,9 @@ jobs:
         run: pnpm vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Set outputs
         id: vars
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: |
+          git config --global --add safe.directory '*'
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Assign Alias
         if: github.ref != 'refs/heads/main'
         run: pnpm vercel alias set ${{ steps.deploy.outputs.url }} keychain-${{ steps.vars.outputs.sha_short }}.preview.cartridge.gg --scope=cartridge --token=${{ secrets.VERCEL_TOKEN }}
@@ -125,7 +127,9 @@ jobs:
         run: pnpm vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Set outputs
         id: vars
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: |
+          git config --global --add safe.directory '*'
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Assign Alias
         if: github.ref != 'refs/heads/main'
         run: pnpm vercel alias set ${{ steps.deploy.outputs.url }} keychain-${{ steps.vars.outputs.sha_short }}.preview.cartridge.gg --scope=cartridge --token=${{ secrets.VERCEL_TOKEN }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 scarb 2.7.0
 starknet-foundry 0.18.0
 nodejs v20.11.1
+pnpm 9.7.0

--- a/examples/starknet-react-next/src/app/page.tsx
+++ b/examples/starknet-react-next/src/app/page.tsx
@@ -8,7 +8,6 @@ import { Menu } from "components/Menu";
 import { RegisterSession } from "components/RegisterSession";
 
 export default function Home() {
-  console.log("preview url", process.env.NEXT_PUBLIC_DEPLOYMENT_URL);
   return (
     <div className="flex flex-col p-4 gap-4">
       <div className="flex justify-between">

--- a/examples/starknet-react-next/src/app/page.tsx
+++ b/examples/starknet-react-next/src/app/page.tsx
@@ -8,6 +8,7 @@ import { Menu } from "components/Menu";
 import { RegisterSession } from "components/RegisterSession";
 
 export default function Home() {
+  console.log("preview url", process.env.NEXT_PUBLIC_DEPLOYMENT_URL);
   return (
     <div className="flex flex-col p-4 gap-4">
       <div className="flex justify-between">

--- a/examples/starknet-react-next/src/components/providers/StarknetProvider.tsx
+++ b/examples/starknet-react-next/src/components/providers/StarknetProvider.tsx
@@ -11,7 +11,7 @@ export function StarknetProvider({ children }: PropsWithChildren) {
     <StarknetConfig
       autoConnect
       chains={[sepolia]}
-      connectors={[cartridge]}
+      connectors={[controller]}
       explorer={starkscan}
       provider={provider}
     >
@@ -23,7 +23,7 @@ export function StarknetProvider({ children }: PropsWithChildren) {
 const ETH_TOKEN_ADDRESS =
   "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7";
 
-const cartridge = new CartridgeConnector({
+const controller = new CartridgeConnector({
   policies: [
     {
       target: ETH_TOKEN_ADDRESS,
@@ -48,7 +48,8 @@ const cartridge = new CartridgeConnector({
       method: "allowance",
     },
   ],
-  url: getKeychainUrl(),
+  url:
+    process.env.NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL ?? process.env.XFRAME_URL,
   rpc: process.env.NEXT_PUBLIC_RPC_SEPOLIA,
   paymaster: {
     caller: shortString.encodeShortString("ANY_CALLER"),
@@ -56,16 +57,6 @@ const cartridge = new CartridgeConnector({
   // theme: "dope-wars",
   // colorMode: "light"
 });
-
-function getKeychainUrl() {
-  switch (window.location.hostname) {
-    case "localhost":
-    case "cartridge-starknet-react-next.preview.cartridge.gg":
-      return process.env.XFRAME_URL;
-    default:
-      process.env.NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL;
-  }
-}
 
 function provider(chain: Chain) {
   switch (chain) {

--- a/examples/starknet-react-next/src/components/providers/StarknetProvider.tsx
+++ b/examples/starknet-react-next/src/components/providers/StarknetProvider.tsx
@@ -48,16 +48,7 @@ const cartridge = new CartridgeConnector({
       method: "allowance",
     },
   ],
-  url:
-    !process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL ||
-    process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL.split(".")[0] ===
-      "cartridge-starknet-react-next"
-      ? process.env.XFRAME_URL
-      : "https://" +
-        (process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL ?? "").replace(
-          "cartridge-starknet-react-next",
-          "keychain",
-        ),
+  url: getKeychainUrl(),
   rpc: process.env.NEXT_PUBLIC_RPC_SEPOLIA,
   paymaster: {
     caller: shortString.encodeShortString("ANY_CALLER"),
@@ -65,6 +56,16 @@ const cartridge = new CartridgeConnector({
   // theme: "dope-wars",
   // colorMode: "light"
 });
+
+function getKeychainUrl() {
+  switch (window.location.hostname) {
+    case "localhost":
+    case "cartridge-starknet-react-next.preview.cartridge.gg":
+      return process.env.XFRAME_URL;
+    default:
+      process.env.NEXT_PUBLIC_KEYCHAIN_DEPLOYMENT_URL;
+  }
+}
 
 function provider(chain: Chain) {
   switch (chain) {


### PR DESCRIPTION
This change introduces a step to assign a URL alias for Vercel preview deployments in GitHub Actions. It ensures preview URLs follow a consistent pattern and are easily identifiable by including the commit SHA.