### PR TITLE
Add rust-cache action to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
       - name: Cache turbo build setup
         uses: actions/cache@v4
         with:
@@ -71,6 +72,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
       - name: Cache turbo build setup
         uses: actions/cache@v4
         with:
@@ -125,6 +127,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
       - name: Cache turbo build setup
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
           components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-llvm-cov
       - run: cargo llvm-cov --all-features --lcov --output-path lcov.info
       - uses: codecov/codecov-action@v3


### PR DESCRIPTION
This commit introduces the Swatinem/rust-cache action to the GitHub deploy workflow. The action helps in caching Rust dependencies, potentially speeding up the build process in subsequent runs.