### PR TITLE
Only build related packages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build
-        run: pnpm build
+        run: pnpm build:deps && pnpm keychain build
       - name: Pull Vercel Environment Information (Preview)
         if: github.ref != 'refs/heads/main'
         run: pnpm vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
@@ -107,7 +107,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build
-        run: pnpm build
+        run: pnpm build:deps && pnpm keychain storybook:build
       - name: Pull Vercel Environment Information (Preview)
         if: github.ref != 'refs/heads/main'
         run: pnpm vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
@@ -171,7 +171,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build
-        run: pnpm build
+        run: pnpm build:deps && pnpm example:next build
       - name: Pull Vercel Environment Information (Preview)
         if: github.ref != 'refs/heads/main'
         run: pnpm vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "build": "turbo build:deps build",
+    "build:deps": "turbo build:deps",
     "dev": "turbo build:deps dev",
     "storybook": "pnpm turbo build:deps storybook",
     "e2e": "turbo build:deps dev e2e",


### PR DESCRIPTION
Make it easier to identify where the build error comes from.

i.e. keychain deploy job should not fail when there's a build error on keychain-storybook
<img width="1624" alt="Screenshot 2024-09-17 at 12 04 39" src="https://github.com/user-attachments/assets/31d32cb1-0d25-42c5-94d4-ee7825d4e7a9">
