### PR TITLE
Remove redundant build steps in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,9 +42,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build
-        run: |
-          pnpm build:deps
-          pnpm --filter "keychain" build
+        run: pnpm build:deps
       - name: Pull Vercel Environment Information (Preview)
         if: github.ref != 'refs/heads/main'
         run: pnpm vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
@@ -107,9 +105,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build
-        run: |
-          pnpm build:deps
-          pnpm --filter "keychain-storybook" build
+        run: pnpm build:deps
       - name: Pull Vercel Environment Information (Preview)
         if: github.ref != 'refs/heads/main'
         run: pnpm vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
@@ -172,9 +168,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build
-        run: |
-          pnpm build:deps
-          pnpm --filter "starknet-react-next" build
+        run: pnpm build:deps
       - name: Pull Vercel Environment Information (Preview)
         if: github.ref != 'refs/heads/main'
         run: pnpm vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
The build steps for keychain, keychain-storybook, and starknet-react-next have been removed from the deploy workflow YAML file. This simplifies the workflow and reduces unnecessary actions, streamlining the deployment process.