### PR TITLE
Fix rust workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       image: ghcr.io/dojoengine/dojo-dev:v1.0.0-alpha.4
     steps:
       - uses: actions/checkout@v4
+      - run: git config --system --add safe.directory '*'
       - uses: dorny/paths-filter@v3
         id: changes
         with:


### PR DESCRIPTION
This change ensures that the working directory is recognized as a safe directory by Git. By adding this configuration, potential permission issues with Git operations in the workflow environment are mitigated.