### PR TITLE
fix: fee estimation multiplier

### DIFF
--- a/packages/account-wasm/src/lib.rs
+++ b/packages/account-wasm/src/lib.rs
@@ -177,7 +177,6 @@ impl CartridgeAccount {
     pub async fn estimate_invoke_fee(
         &self,
         calls: Vec<JsCall>,
-        fee_multiplier: Option<f64>,
     ) -> std::result::Result<JsValue, JsControllerError> {
         set_panic_hook();
 
@@ -186,11 +185,7 @@ impl CartridgeAccount {
             .map(TryFrom::try_from)
             .collect::<std::result::Result<Vec<_>, _>>()?;
 
-        let fee_estimate = self
-            .controller
-            .estimate_invoke_fee(calls, fee_multiplier)
-            .await?;
-
+        let fee_estimate = self.controller.estimate_invoke_fee(calls).await?;
         Ok(to_value(&fee_estimate)?)
     }
 

--- a/packages/account_sdk/src/controller.rs
+++ b/packages/account_sdk/src/controller.rs
@@ -257,13 +257,10 @@ where
     pub async fn estimate_invoke_fee(
         &self,
         calls: Vec<Call>,
-        fee_multiplier: Option<f64>,
     ) -> Result<FeeEstimate, ControllerError> {
-        let multiplier = fee_multiplier.unwrap_or(1.0);
         let est = self
             .execute_v1(calls)
             .nonce(Felt::from(u64::MAX))
-            .fee_estimate_multiplier(multiplier)
             .estimate_fee()
             .await;
 

--- a/packages/keychain/src/components/ExecutionContainer.tsx
+++ b/packages/keychain/src/components/ExecutionContainer.tsx
@@ -55,7 +55,7 @@ export function ExecutionContainer({
           transactions,
           transactionsDetail,
         );
-        setMaxFee(est.overall_fee);
+        setMaxFee(est.suggestedMaxFee);
       } catch (e) {
         const error = {
           code: e.code,

--- a/packages/keychain/src/utils/account.ts
+++ b/packages/keychain/src/utils/account.ts
@@ -105,7 +105,7 @@ class Account extends BaseAccount {
     const res = await this.cartridge.estimateInvokeFee(normalizeCalls(calls));
 
     // The reason why we set the multiplier unseemingly high is to account
-    // for the fact that the estimatation above is done without validation (SKIP_VALIDATE).
+    // for the fact that the estimation above is done without validation (ie SKIP_VALIDATE).
     //
     // Setting it lower might cause the actual transaction to fail due to
     // insufficient max fee.

--- a/packages/keychain/src/utils/account.ts
+++ b/packages/keychain/src/utils/account.ts
@@ -102,13 +102,13 @@ class Account extends BaseAccount {
       return BigInt(result) / BigInt(scaleFactor);
     }
 
+    const res = await this.cartridge.estimateInvokeFee(normalizeCalls(calls));
+
     // The reason why we set the multiplier unseemingly high is to account
-    // for the fact that the estimate is done without validation.
+    // for the fact that the estimatation above is done without validation (SKIP_VALIDATE).
     //
     // Setting it lower might cause the actual transaction to fail due to
     // insufficient max fee.
-    const res = await this.cartridge.estimateInvokeFee(normalizeCalls(calls));
-
     const ESTIMATE_FEE_MULITPLIER = 1.7;
     const suggestedMaxFee = bigint_mul_float(
       BigInt(res.overall_fee),


### PR DESCRIPTION
remove unused fee multiplier field in account-wasm/account-sdk. is it unused because setting the `fee_estimate_multiplier` here is pretty much a no-op because we call the `estimate_fee()` and not `send()`.

https://github.com/cartridge-gg/controller/blob/c283c0e3671b732b54ee8eea11b4da970d767efd/packages/account_sdk/src/controller.rs#L263-L268

this PR removes all references of fee multiplier on account-wasm side and compute it on javascript end instead.