### PR TITLE
Hide session request on login page

### DIFF
--- a/packages/keychain/src/components/connect/Login.tsx
+++ b/packages/keychain/src/components/connect/Login.tsx
@@ -139,7 +139,7 @@ function Form({
         />
       </Content>
 
-      <Footer isSlot={isSlot} showCatridgeLogo>
+      <Footer isSlot={isSlot} showCatridgeLogo hideTxSummary>
         {error && (
           <ErrorAlert
             title="Login failed"


### PR DESCRIPTION
Create session is a distinct step during login now so no need to show request summary