### PR TITLE
fix: use raw string to avoid windows path considered as escaping

### DIFF
--- a/packages/account_sdk/build.rs
+++ b/packages/account_sdk/build.rs
@@ -32,7 +32,7 @@ fn generate_constants() {
 
                 controllers.push_str(&format!(
                     r#"m.insert(Version::{}, ContractClass {{
-            content: include_str!(".{}"),
+            content: include_str!(r".{}"),
             hash: felt!("{:#x}"),
             casm_hash: felt!("{:#x}"),
         }});"#,

--- a/packages/account_sdk/src/constants.rs
+++ b/packages/account_sdk/src/constants.rs
@@ -26,7 +26,7 @@ lazy_static! {
         m.insert(
             Version::LATEST,
             ContractClass {
-                content: include_str!("../compiled/controller.latest.contract_class.json"),
+                content: include_str!(r"../compiled/controller.latest.contract_class.json"),
                 hash: felt!("0x32e17891b6cc89e0c3595a3df7cee760b5993744dc8dfef2bd4d443e65c0f40"),
                 casm_hash: felt!(
                     "0x46b6264bd23cdea881b1b1110d7e1e5408507fa847f053ca9b272f4cbe1d55c"
@@ -36,7 +36,7 @@ lazy_static! {
         m.insert(
             Version::V1_0_5,
             ContractClass {
-                content: include_str!("../compiled/controller.v1.0.5.contract_class.json"),
+                content: include_str!(r"../compiled/controller.v1.0.5.contract_class.json"),
                 hash: felt!("0x32e17891b6cc89e0c3595a3df7cee760b5993744dc8dfef2bd4d443e65c0f40"),
                 casm_hash: felt!(
                     "0x46b6264bd23cdea881b1b1110d7e1e5408507fa847f053ca9b272f4cbe1d55c"
@@ -46,7 +46,7 @@ lazy_static! {
         m.insert(
             Version::V1_0_4,
             ContractClass {
-                content: include_str!("../compiled/controller.v1.0.4.contract_class.json"),
+                content: include_str!(r"../compiled/controller.v1.0.4.contract_class.json"),
                 hash: felt!("0x24a9edbfa7082accfceabf6a92d7160086f346d622f28741bf1c651c412c9ab"),
                 casm_hash: felt!(
                     "0x6b22de13b878ab346fa53442adaa8a40a6bd25732aa1aeb2a26375987f0be00"

--- a/packages/account_sdk/src/tests/account/declare.rs
+++ b/packages/account_sdk/src/tests/account/declare.rs
@@ -15,7 +15,7 @@ use super::pending::PendingTransaction;
 
 pub const ERC_20_COMPILED_CLASS_HASH: Felt =
     felt!("0x732654ca6baa90ff202d2fcc35fb39766eb34842a7e5ac6dbf7714af71f1dab");
-pub const ERC_20_SIERRA_STR: &str = include_str!("../../../compiled/erc20.contract_class.json");
+pub const ERC_20_SIERRA_STR: &str = include_str!(r"../../../compiled/erc20.contract_class.json");
 
 pub struct AccountDeclaration<'a> {
     contract_artifact: SierraClass,


### PR DESCRIPTION
Related to dojo error: https://github.com/dojoengine/dojo/actions/runs/10948582548/job/30400215646?pr=2454.