### PR TITLE
Pass address and indexerUrl to profile page via url search params

### DIFF
--- a/examples/starknet-react-next/src/components/Profile.tsx
+++ b/examples/starknet-react-next/src/components/Profile.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useAccount } from "@starknet-react/core";
-import CartridgeConnector from "@cartridge/connector";
+import ControllerConnector from "@cartridge/connector";
 import { Button } from "@cartridge/ui-next";
 
 export function Profile() {
   const { account, connector } = useAccount();
-  const cartridgeConnector = connector as unknown as CartridgeConnector;
+  const ctrlConnector = connector as unknown as ControllerConnector;
 
   if (!account) {
     return null;
@@ -14,10 +14,18 @@ export function Profile() {
 
   return (
     <div>
-      <h2>Open Menu</h2>
-      <Button onClick={() => cartridgeConnector.openProfile()}>
-        Open Profile
-      </Button>
+      <h2>Open Profile</h2>
+      <div className="flex gap-1">
+        <Button onClick={() => ctrlConnector.controller.openProfile("quest")}>
+          Quest
+        </Button>
+        <Button onClick={() => ctrlConnector.controller.openProfile()}>
+          Inventory
+        </Button>
+        <Button onClick={() => ctrlConnector.controller.openProfile("history")}>
+          History
+        </Button>
+      </div>
     </div>
   );
 }

--- a/examples/starknet-react-next/src/components/providers/StarknetProvider.tsx
+++ b/examples/starknet-react-next/src/components/providers/StarknetProvider.tsx
@@ -54,6 +54,7 @@ const controller = new ControllerConnector({
   profileUrl:
     process.env.NEXT_PUBLIC_PROFILE_DEPLOYMENT_URL ??
     process.env.PROFILE_FRAME_URL,
+  indexerUrl: "http://localhost:8080",
   rpc: process.env.NEXT_PUBLIC_RPC_SEPOLIA,
   paymaster: {
     caller: shortString.encodeShortString("ANY_CALLER"),

--- a/packages/connector/src/index.ts
+++ b/packages/connector/src/index.ts
@@ -71,10 +71,6 @@ class ControllerConnector extends Connector {
   async openMenu() {
     return await this.controller.openMenu();
   }
-
-  openProfile() {
-    return this.controller.openProfile();
-  }
 }
 
 export default ControllerConnector;

--- a/packages/controller/src/iframe/base.ts
+++ b/packages/controller/src/iframe/base.ts
@@ -99,6 +99,15 @@ export class IFrame<CallSender extends {}> implements Modal {
     this.onClose = onClose;
   }
 
+  currentUrl() {
+    return this.iframe ? new URL(this.iframe.src) : undefined;
+  }
+
+  updateUrl(url: URL) {
+    if (!this.iframe) return;
+    this.iframe.src = url.toString();
+  }
+
   open() {
     if (!this.container) return;
     document.body.style.overflow = "hidden";

--- a/packages/controller/src/iframe/keychain.ts
+++ b/packages/controller/src/iframe/keychain.ts
@@ -1,15 +1,16 @@
 import { KEYCHAIN_URL } from "../constants";
-import { ControllerOptions, Keychain } from "../types";
+import { Keychain, KeychainOptions } from "../types";
 import { IFrame, IFrameOptions } from "./base";
+
+type KeychainIframeOptions = IFrameOptions<Keychain> & KeychainOptions;
 
 export class KeychainIFrame extends IFrame<Keychain> {
   constructor({
     url,
     paymaster,
     policies,
-    ...options
-  }: IFrameOptions<Keychain> &
-    Pick<ControllerOptions, "paymaster" | "policies">) {
+    ...iframeOptions
+  }: KeychainIframeOptions) {
     const _url = new URL(url ?? KEYCHAIN_URL);
     if (paymaster) {
       _url.searchParams.set(
@@ -25,7 +26,7 @@ export class KeychainIFrame extends IFrame<Keychain> {
     }
 
     super({
-      ...options,
+      ...iframeOptions,
       id: "controller-keychain",
       url: _url,
     });

--- a/packages/controller/src/iframe/profile.ts
+++ b/packages/controller/src/iframe/profile.ts
@@ -1,13 +1,34 @@
 import { PROFILE_URL } from "../constants";
-import { Profile } from "../types";
+import { Profile, ProfileOptions } from "../types";
 import { IFrame, IFrameOptions } from "./base";
 
+export type ProfileIFrameOptions = IFrameOptions<Profile> &
+  ProfileOptions & {
+    address: string;
+    indexerUrl: string;
+  };
+
 export class ProfileIFrame extends IFrame<Profile> {
-  constructor(options: IFrameOptions<Profile>) {
+  constructor({
+    profileUrl,
+    address,
+    indexerUrl,
+    ...iframeOptions
+  }: ProfileIFrameOptions) {
+    const _url = new URL(profileUrl ?? PROFILE_URL);
+    _url.searchParams.set(
+      "address",
+      encodeURIComponent(JSON.stringify(address)),
+    );
+    _url.searchParams.set(
+      "indexerUrl",
+      encodeURIComponent(JSON.stringify(indexerUrl)),
+    );
+
     super({
-      ...options,
+      ...iframeOptions,
       id: "controller-profile",
-      url: new URL(options.url ?? PROFILE_URL),
+      url: _url,
     });
   }
 }

--- a/packages/controller/src/iframe/profile.ts
+++ b/packages/controller/src/iframe/profile.ts
@@ -5,6 +5,7 @@ import { IFrame, IFrameOptions } from "./base";
 export type ProfileIFrameOptions = IFrameOptions<Profile> &
   ProfileOptions & {
     address: string;
+    username: string;
     indexerUrl: string;
   };
 
@@ -12,18 +13,14 @@ export class ProfileIFrame extends IFrame<Profile> {
   constructor({
     profileUrl,
     address,
+    username,
     indexerUrl,
     ...iframeOptions
   }: ProfileIFrameOptions) {
     const _url = new URL(profileUrl ?? PROFILE_URL);
-    _url.searchParams.set(
-      "address",
-      encodeURIComponent(JSON.stringify(address)),
-    );
-    _url.searchParams.set(
-      "indexerUrl",
-      encodeURIComponent(JSON.stringify(indexerUrl)),
-    );
+    _url.searchParams.set("address", encodeURIComponent(address));
+    _url.searchParams.set("username", encodeURIComponent(username));
+    _url.searchParams.set("indexerUrl", encodeURIComponent(indexerUrl));
 
     super({
       ...iframeOptions,

--- a/packages/controller/src/iframe/profile.ts
+++ b/packages/controller/src/iframe/profile.ts
@@ -1,5 +1,5 @@
 import { PROFILE_URL } from "../constants";
-import { Profile, ProfileOptions } from "../types";
+import { Profile, ProfileOptions, ProfileTabVariant } from "../types";
 import { IFrame, IFrameOptions } from "./base";
 
 export type ProfileIFrameOptions = IFrameOptions<Profile> &
@@ -30,5 +30,15 @@ export class ProfileIFrame extends IFrame<Profile> {
       id: "controller-profile",
       url: _url,
     });
+  }
+
+  openTab(tab: ProfileTabVariant) {
+    const url = super.currentUrl();
+    if (!url) return;
+
+    url.searchParams.set("tab", tab);
+
+    super.updateUrl(url);
+    super.open();
   }
 }

--- a/packages/controller/src/index.ts
+++ b/packages/controller/src/index.ts
@@ -174,8 +174,8 @@ export default class Controller {
     }
   }
 
-  openProfile() {
-    if (this.profileOptions.indexerUrl) {
+  openProfile(tab: "quest" | "inventory" | "history" = "inventory") {
+    if (!this.profileOptions.indexerUrl) {
       console.error("`indexerUrl` option is required to open profile");
       return;
     }
@@ -184,7 +184,7 @@ export default class Controller {
       return;
     }
 
-    this.iframes.profile.open();
+    this.iframes.profile.openTab(tab);
   }
 
   async disconnect() {

--- a/packages/controller/src/index.ts
+++ b/packages/controller/src/index.ts
@@ -120,10 +120,12 @@ export default class Controller {
       this.profileOptions.indexerUrl &&
       !this.iframes.profile
     ) {
+      const username = await this.keychain.username();
       this.iframes.profile = new ProfileIFrame({
         profileUrl: this.profileOptions.profileUrl,
         indexerUrl: this.profileOptions.indexerUrl,
         address: this.account.address,
+        username,
         onConnect: (profile) => {
           this.profile = profile;
         },

--- a/packages/controller/src/index.ts
+++ b/packages/controller/src/index.ts
@@ -115,7 +115,7 @@ export default class Controller {
       return;
     }
 
-    if (this.profileOptions.indexerUrl) {
+    if (this.profileOptions.profileUrl && this.profileOptions.indexerUrl) {
       this.iframes.profile = new ProfileIFrame({
         profileUrl: this.profileOptions.profileUrl,
         indexerUrl: this.profileOptions.indexerUrl,
@@ -175,6 +175,10 @@ export default class Controller {
   }
 
   openProfile() {
+    if (this.profileOptions.indexerUrl) {
+      console.error("`indexerUrl` option is required to open profile");
+      return;
+    }
     if (!this.profile || !this.iframes.profile) {
       console.error(new ProfileNotReady().message);
       return;

--- a/packages/controller/src/index.ts
+++ b/packages/controller/src/index.ts
@@ -115,7 +115,11 @@ export default class Controller {
       return;
     }
 
-    if (this.profileOptions.profileUrl && this.profileOptions.indexerUrl) {
+    if (
+      this.profileOptions.profileUrl &&
+      this.profileOptions.indexerUrl &&
+      !this.iframes.profile
+    ) {
       this.iframes.profile = new ProfileIFrame({
         profileUrl: this.profileOptions.profileUrl,
         indexerUrl: this.profileOptions.indexerUrl,

--- a/packages/controller/src/types.ts
+++ b/packages/controller/src/types.ts
@@ -14,7 +14,7 @@ import {
   DeployAccountSignerDetails,
   DeclareSignerDetails,
 } from "starknet";
-import { IFrame } from "./iframe";
+import { KeychainIFrame, ProfileIFrame } from "./iframe";
 
 export type Session = {
   chainId: constants.StarknetChainId;
@@ -78,8 +78,8 @@ export type DeployReply = {
 };
 
 export type IFrames = {
-  keychain: IFrame<Keychain>;
-  profile?: IFrame<Profile>;
+  keychain: KeychainIFrame;
+  profile?: ProfileIFrame;
 };
 
 export interface Keychain {
@@ -180,6 +180,8 @@ export type ProfileOptions = IFrameOptions & {
   /** The URL of Torii indexer. Will be mandatory once profile page is in production */
   indexerUrl?: string;
 };
+
+export type ProfileTabVariant = "quest" | "inventory" | "history";
 
 /**
  * Options for configuring a paymaster

--- a/packages/controller/src/types.ts
+++ b/packages/controller/src/types.ts
@@ -79,7 +79,7 @@ export type DeployReply = {
 
 export type IFrames = {
   keychain: IFrame<Keychain>;
-  profile: IFrame<Profile>;
+  profile?: IFrame<Profile>;
 };
 
 export interface Keychain {
@@ -144,18 +144,9 @@ export interface Modal {
 /**
  * Options for configuring the controller
  */
-export type ControllerOptions = {
-  policies?: Policy[];
-  /** The URL of keychain */
-  url?: string;
-  /** The URL of profile. Mainly for internal development purpose */
-  profileUrl?: string;
-  /** The URL of the RPC */
-  rpc?: string;
-  /** The origin of keychain */
-  origin?: string;
-  /** Paymaster options for transaction fee management */
-  paymaster?: PaymasterOptions;
+export type ControllerOptions = KeychainOptions & ProfileOptions;
+
+export type IFrameOptions = {
   /** The ID of the starter pack to use */
   starterPackId?: string;
   /** The theme to use */
@@ -167,8 +158,26 @@ export type ControllerOptions = {
     /** Preset themes for the controller */
     presets?: ControllerThemePresets;
   };
+};
+
+export type KeychainOptions = IFrameOptions & {
+  policies?: Policy[];
+  /** The URL of keychain */
+  url?: string;
+  /** The URL of the RPC */
+  rpc?: string;
+  /** The origin of keychain */
+  origin?: string;
+  /** Paymaster options for transaction fee management */
+  paymaster?: PaymasterOptions;
   /** List of ERC20 tokens to pre-fund */
   // prefunds?: Prefund[];
+};
+
+export type ProfileOptions = IFrameOptions & {
+  /** The URL of profile. Mainly for internal development purpose */
+  profileUrl?: string;
+  indexerUrl?: string;
 };
 
 /**

--- a/packages/controller/src/types.ts
+++ b/packages/controller/src/types.ts
@@ -177,6 +177,7 @@ export type KeychainOptions = IFrameOptions & {
 export type ProfileOptions = IFrameOptions & {
   /** The URL of profile. Mainly for internal development purpose */
   profileUrl?: string;
+  /** The URL of Torii indexer. Will be mandatory once profile page is in production */
   indexerUrl?: string;
 };
 

--- a/packages/profile/index.html
+++ b/packages/profile/index.html
@@ -30,6 +30,17 @@
       data-domain="cartridge.gg"
       src="https://plausible.io/js/script.js"
     ></script>
+    <script>
+      if (
+        localStorage.getItem("vite-ui-colorScheme") === "dark" ||
+        (!("vite-ui-colorScheme" in localStorage) &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches)
+      ) {
+        document.querySelector("html").classList.add("dark");
+      } else {
+        document.querySelector("html").classList.remove("dark");
+      }
+    </script>
   </head>
   <body class="bg-background text-foreground">
     <div id="root"></div>

--- a/packages/profile/index.html
+++ b/packages/profile/index.html
@@ -25,24 +25,14 @@
       property="theme-color"
       content="{CartridgeTheme.semanticTokens.colors.brand}"
     />
+    <script src="/noflash.js"></script>
     <script
       defer
       data-domain="cartridge.gg"
       src="https://plausible.io/js/script.js"
     ></script>
-    <script>
-      if (
-        localStorage.getItem("vite-ui-colorScheme") === "dark" ||
-        (!("vite-ui-colorScheme" in localStorage) &&
-          window.matchMedia("(prefers-color-scheme: dark)").matches)
-      ) {
-        document.querySelector("html").classList.add("dark");
-      } else {
-        document.querySelector("html").classList.remove("dark");
-      }
-    </script>
   </head>
-  <body class="bg-background text-foreground">
+  <body class="h-screen bg-background text-foreground">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/packages/profile/public/noflash.js
+++ b/packages/profile/public/noflash.js
@@ -1,0 +1,25 @@
+(function () {
+  const storageKey = "vite-ui-colorScheme";
+  const classNameDark = "dark";
+  const params = new URL(document.location).searchParams;
+  const colorScheme =
+    params.get("colorMode") ?? localStorage.getItem(storageKey) ?? "system";
+  const html = document.getElementsByTagName("html")[0];
+
+  switch (colorScheme) {
+    case "light":
+      break;
+    case "dark":
+      html.classList.add(classNameDark);
+      break;
+    case "system":
+      if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+        html.classList.add(classNameDark);
+      }
+      break;
+    default:
+      break;
+  }
+
+  localStorage.setItem(storageKey, colorScheme);
+})();

--- a/packages/profile/src/components/app.tsx
+++ b/packages/profile/src/components/app.tsx
@@ -1,0 +1,18 @@
+import { useQueryParams } from "@/components/provider/hooks";
+import { Inventory } from "@/components/inventory";
+import { Quest } from "@/components/quest";
+import { History } from "@/components/history";
+
+export function App() {
+  const searchParams = useQueryParams();
+
+  switch (searchParams.get("tab")) {
+    case "quest":
+      return <Quest />;
+    case "history":
+      return <History />;
+    default:
+    case "inventory":
+      return <Inventory />;
+  }
+}

--- a/packages/profile/src/components/history.tsx
+++ b/packages/profile/src/components/history.tsx
@@ -4,7 +4,7 @@ import {
   LayoutHeader,
 } from "@/components/layout";
 
-export function Inventory() {
+export function History() {
   return (
     <LayoutContainer>
       <LayoutHeader
@@ -13,7 +13,7 @@ export function Inventory() {
       />
 
       <LayoutContent>
-        <div>Inventory</div>
+        <div>History</div>
       </LayoutContent>
     </LayoutContainer>
   );

--- a/packages/profile/src/components/inventory.tsx
+++ b/packages/profile/src/components/inventory.tsx
@@ -3,14 +3,14 @@ import {
   LayoutContent,
   LayoutHeader,
 } from "@/components/layout";
+import { useConnection } from "./provider/hooks";
 
 export function Inventory() {
+  const { username, address } = useConnection();
+
   return (
     <LayoutContainer>
-      <LayoutHeader
-        title={"click.ctrl"}
-        description={"0x0000000...0000000000"}
-      />
+      <LayoutHeader title={username} description={address} />
 
       <LayoutContent>
         <div>Inventory</div>

--- a/packages/profile/src/components/layout/index.tsx
+++ b/packages/profile/src/components/layout/index.tsx
@@ -65,10 +65,12 @@ export function LayoutHeader({ title, description }: LayoutHeaderProps) {
         />
       </div>
 
-      <div>
-        <div className="text-lg font-semibold">{title}</div>
+      <div className="overflow-hidden">
+        <div className="text-lg font-semibold truncate">{title}</div>
         {description && (
-          <div className="text-xs text-accent-foreground">{description}</div>
+          <div className="text-xs text-accent-foreground truncate">
+            {description}
+          </div>
         )}
       </div>
     </div>

--- a/packages/profile/src/components/layout/index.tsx
+++ b/packages/profile/src/components/layout/index.tsx
@@ -58,17 +58,17 @@ type LayoutHeaderProps = {
 export function LayoutHeader({ title, description }: LayoutHeaderProps) {
   return (
     <div className="flex gap-2 px-4 py-6 sticky top-16 bg-background">
-      <div className="w-11 h-11 bg-secondary rounded flex items-center justify-center">
+      <div className="w-11 h-11 bg-secondary rounded flex shrink-0 items-center justify-center">
         <img
           className="w-8 h-8"
           src={"https://x.cartridge.gg/whitelabel/cartridge/icon.svg"}
         />
       </div>
 
-      <div className="overflow-hidden">
+      <div className="flex flex-col gap-1 overflow-hidden">
         <div className="text-lg font-semibold truncate">{title}</div>
         {description && (
-          <div className="text-xs text-accent-foreground truncate">
+          <div className="text-xs text-muted-foreground truncate">
             {description}
           </div>
         )}

--- a/packages/profile/src/components/provider/colorScheme.tsx
+++ b/packages/profile/src/components/provider/colorScheme.tsx
@@ -1,4 +1,4 @@
-import { createContext, useEffect, useState } from "react";
+import { createContext, useCallback, useEffect, useState } from "react";
 import { useQueryParams } from "./hooks";
 
 type ColorScheme = "dark" | "light" | "system";
@@ -39,11 +39,19 @@ export function ColorSchemeProvider({
     );
   }
 
-  const [colorScheme, setColorScheme] = useState<ColorScheme>(
+  const [colorScheme, setColorSchemeRaw] = useState<ColorScheme>(
     () =>
       colorSchemeParam ||
       (localStorage.getItem(storageKey) as ColorScheme) ||
       defaultScheme,
+  );
+
+  const setColorScheme = useCallback(
+    (colorScheme: ColorScheme) => {
+      localStorage.setItem(storageKey, colorScheme);
+      setColorSchemeRaw(colorScheme);
+    },
+    [storageKey],
   );
 
   useEffect(() => {
@@ -58,18 +66,17 @@ export function ColorSchemeProvider({
         : "light";
 
       root.classList.add(systemScheme);
+      setColorScheme(colorScheme);
       return;
     }
 
     root.classList.add(colorScheme);
-  }, [colorScheme]);
+    setColorScheme(colorScheme);
+  }, [colorScheme, setColorScheme]);
 
   const value = {
     colorScheme,
-    setColorScheme: (colorScheme: ColorScheme) => {
-      localStorage.setItem(storageKey, colorScheme);
-      setColorScheme(colorScheme);
-    },
+    setColorScheme,
   };
 
   return (

--- a/packages/profile/src/components/provider/colorScheme.tsx
+++ b/packages/profile/src/components/provider/colorScheme.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useEffect, useState } from "react";
+import { createContext, useCallback, useState } from "react";
 import { useQueryParams } from "./hooks";
 
 type ColorScheme = "dark" | "light" | "system";
@@ -53,26 +53,6 @@ export function ColorSchemeProvider({
     },
     [storageKey],
   );
-
-  useEffect(() => {
-    const root = window.document.documentElement;
-
-    root.classList.remove("light", "dark");
-
-    if (colorScheme === "system") {
-      const systemScheme = window.matchMedia("(prefers-color-scheme: dark)")
-        .matches
-        ? "dark"
-        : "light";
-
-      root.classList.add(systemScheme);
-      setColorScheme(colorScheme);
-      return;
-    }
-
-    root.classList.add(colorScheme);
-    setColorScheme(colorScheme);
-  }, [colorScheme, setColorScheme]);
 
   const value = {
     colorScheme,

--- a/packages/profile/src/components/provider/connection.tsx
+++ b/packages/profile/src/components/provider/connection.tsx
@@ -1,13 +1,18 @@
 import { AsyncMethodReturns, connectToParent } from "@cartridge/penpal";
 import { createContext, useState, ReactNode, useEffect } from "react";
+import { useQueryParams } from "./hooks";
 
 type ConnectionContextType = {
   parent: ParentMethods;
+  address: string;
+  username: string;
 };
 type ParentMethods = AsyncMethodReturns<{ close: () => Promise<void> }>;
 
 const initialState: ConnectionContextType = {
   parent: { close: async () => {} },
+  address: "",
+  username: "",
 };
 
 export const ConnectionContext =
@@ -28,6 +33,15 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
       connection.destroy();
     };
   }, []);
+
+  const searchParams = useQueryParams();
+  useEffect(() => {
+    setState((state) => ({
+      ...state,
+      address: decodeURIComponent(searchParams.get("address")!),
+      username: decodeURIComponent(searchParams.get("username")!),
+    }));
+  }, [searchParams]);
 
   return (
     <ConnectionContext.Provider value={state}>

--- a/packages/profile/src/components/quest.tsx
+++ b/packages/profile/src/components/quest.tsx
@@ -4,7 +4,7 @@ import {
   LayoutHeader,
 } from "@/components/layout";
 
-export function Inventory() {
+export function Quest() {
   return (
     <LayoutContainer>
       <LayoutHeader
@@ -13,7 +13,7 @@ export function Inventory() {
       />
 
       <LayoutContent>
-        <div>Inventory</div>
+        <div>Quest</div>
       </LayoutContent>
     </LayoutContainer>
   );

--- a/packages/profile/src/main.tsx
+++ b/packages/profile/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { Inventory } from "@/components/inventory";
+import { App } from "@/components/app";
 import { Provider } from "@/components/provider";
 
 import "./index.css";
@@ -8,7 +8,7 @@ import "./index.css";
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <Provider>
-      <Inventory />
+      <App />
     </Provider>
   </StrictMode>,
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26419,8 +26419,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.29.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@2.7.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.1(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -26442,11 +26442,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.29.1)(eslint@8.57.0):
+  eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 4.3.4
       eslint: 8.57.0
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@2.7.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.8
@@ -26461,11 +26461,11 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@2.7.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5


### PR DESCRIPTION
Profile iframe is initialized only after keychain is ready because account address is required.
`indexerUrl` field is optional for now. It consoles out error when dapps trigger `openProfile` without providing the `indexerUrl`.