### PR TITLE
ci: ensure Windows build for `account_sdk`

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -24,7 +24,6 @@ jobs:
           cargo build -r --target wasm32-unknown-unknown -p account_sdk
 
   ensure-windows:
-    needs: ensure-docker
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,6 +23,17 @@ jobs:
           cd packages/account_sdk
           cargo build -r --target wasm32-unknown-unknown -p account_sdk
 
+  ensure-windows:
+    needs: ensure-docker
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          target: x86_64-pc-windows-msvc
+      - run: cargo build --target x86_64-pc-windows-msvc -p account_sdk
+
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/packages/account_sdk/build.rs
+++ b/packages/account_sdk/build.rs
@@ -37,6 +37,8 @@ fn generate_constants() {
             casm_hash: felt!("{:#x}"),
         }});"#,
                     version.replace('.', "_").to_uppercase(),
+                    // Replace the '\' with '/' on Windows, meaning the path is always the same
+                    // on all platforms. Windows also accepts '/' as a path separator.
                     path.display().to_string().replace("\\", "/"),
                     extract_class_hash(&path),
                     extract_compiled_class_hash(version)

--- a/packages/account_sdk/build.rs
+++ b/packages/account_sdk/build.rs
@@ -37,7 +37,7 @@ fn generate_constants() {
             casm_hash: felt!("{:#x}"),
         }});"#,
                     version.replace('.', "_").to_uppercase(),
-                    path.display(),
+                    path.display().to_string().replace("\\", "/"),
                     extract_class_hash(&path),
                     extract_compiled_class_hash(version)
                 ));


### PR DESCRIPTION
ref: https://github.com/dojoengine/dojo/pull/2454

to ensure on the Dojo side that `account_sdk` would always be compilable to Windows target
