### PR TITLE
Add format:fix scripts

### DIFF
--- a/examples/starknet-react-next/package.json
+++ b/examples/starknet-react-next/package.json
@@ -9,7 +9,7 @@
     "e2e:ui": "playwright test --ui",
     "start": "next start -p 3002",
     "lint": "next lint",
-    "format": "prettier --write ./src",
+    "format:fix": "prettier --write ./src",
     "format:check": "prettier --check ./src"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "e2e": "turbo build:deps dev e2e",
     "e2e:ui": "turbo build:deps dev e2e:ui",
     "lint": "turbo lint format:check",
+    "fix": "turbo lint format:fix",
     "format": "turbo format",
     "clean": "git clean -xdf && pnpm store prune",
     "release": "pnpm build && pnpm changeset publish",

--- a/packages/connector/package.json
+++ b/packages/connector/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build:deps": "tsc",
     "prepublish": "pnpm build:deps",
-    "format": "prettier --write \"src/**/*.ts\"",
+    "format:fix": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\""
   },
   "files": [

--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "build:deps": "tsc",
-    "format": "prettier --write \"src/**/*.ts\"",
+    "format:fix": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\""
   },
   "files": [

--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -7,7 +7,7 @@
     "build": "TARGET_ORIGIN=\"https://x.cartridge.gg/\" next build",
     "start": "next start",
     "lint": "next lint",
-    "format": "prettier --write --ignore-path .gitignore .",
+    "format:fix": "prettier --write --ignore-path .gitignore .",
     "format:check": "prettier --check --ignore-path .gitignore .",
     "test": "jest --watch",
     "test:ci": "jest --ci",

--- a/packages/profile/package.json
+++ b/packages/profile/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "format": "prettier --write ./src index.html",
+    "format:fix": "prettier --write ./src index.html",
     "format:check": "prettier --check ./src index.html",
     "preview": "vite preview"
   },

--- a/packages/ui-next/package.json
+++ b/packages/ui-next/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build:deps": "tsc && tsc-alias && pnpm copyThemes",
     "copyThemes": "cp -R src/themes dist/themes",
-    "format": "prettier --write ./src",
+    "format:fix": "prettier --write ./src",
     "format:check": "prettier --check ./src",
     "lint": "eslint . --ext ts,tsx",
     "storybook": "storybook dev -p 6003",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build:deps": "tsc",
-    "format": "prettier --write ./src",
+    "format:fix": "prettier --write ./src",
     "format:check": "prettier --check ./src",
     "storybook": "storybook dev -p 6002",
     "storybook:build": "storybook build"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build:deps": "tsc",
-    "format": "prettier --write \"src/**/*.ts\"",
+    "format:fix": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\""
   },
   "files": [

--- a/turbo.json
+++ b/turbo.json
@@ -23,7 +23,7 @@
       "dependsOn": ["^build:deps"]
     },
     "lint": {},
-    "format": {},
+    "format:fix": {},
     "format:check": {},
     "e2e": {
       "dependsOn": ["^build:deps"]


### PR DESCRIPTION
Renamed 'format' scripts to 'format:fix' for consistency across all package.json files. This update ensures clarity and uniformity in script naming for fixing code formatting issues.