### PR TITLE
Update deploy cache paths to include new directories

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,8 @@ jobs:
         with:
           path: |
             .turbo
-            packages/account-wasm/pkg
+            packages/account-wasm/pkg-controller
+            packages/account-wasm/pkg-session
           key: ${{ runner.os }}-turbo-cache-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-turbo-cache-${{ github.ref_name }}-
@@ -97,7 +98,8 @@ jobs:
         with:
           path: |
             .turbo
-            packages/account-wasm/pkg
+            packages/account-wasm/pkg-controller
+            packages/account-wasm/pkg-session
           key: ${{ runner.os }}-turbo-cache-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-turbo-cache-${{ github.ref_name }}-
@@ -160,7 +162,8 @@ jobs:
         with:
           path: |
             .turbo
-            packages/account-wasm/pkg
+            packages/account-wasm/pkg-controller
+            packages/account-wasm/pkg-session
           key: ${{ runner.os }}-turbo-cache-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-turbo-cache-${{ github.ref_name }}-
@@ -224,7 +227,8 @@ jobs:
         with:
           path: |
             .turbo
-            packages/account-wasm/pkg
+            packages/account-wasm/pkg-controller
+            packages/account-wasm/pkg-session
           key: ${{ runner.os }}-turbo-cache-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-turbo-cache-${{ github.ref_name }}-


### PR DESCRIPTION
Modified the GitHub Actions deploy workflow to cache additional directories `pkg-controller` and `pkg-session` under `packages/account-wasm`. This ensures that the cache restores correctly for the newly organized packages.