### PR TITLE
`TransactionWaiter` fixed a bug with not erroring when transaction is reverted

### DIFF
--- a/packages/account_sdk/src/tests/mod.rs
+++ b/packages/account_sdk/src/tests/mod.rs
@@ -37,7 +37,7 @@ where
     P: Provider + Sync + Send,
 {
     let tx = execution
-        .fee_estimate_multiplier(1.5)
+        .fee_estimate_multiplier(1.6)
         .send()
         .await
         .map_err(EnsureTxnError::from)?;


### PR DESCRIPTION
When the transaction was reverted due to the `max_fee` being to low, the waiter returned `Ok(...)` instead of an `Err(...)`. This is actually showcased in the run https://github.com/cartridge-gg/controller/actions/runs/11371205654/job/31632747731?pr=871 (The test errored correctly even though it passed previously)