### PR TITLE
Fix parsing logic for starknet tx execution error

### DIFF
--- a/packages/keychain/src/components/ErrorAlert.stories.tsx
+++ b/packages/keychain/src/components/ErrorAlert.stories.tsx
@@ -44,3 +44,10 @@ export const Info: Story = {
     variant: "info",
   },
 };
+
+export const LongTitle: Story = {
+  args: {
+    title:
+      "Long text should align left and blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah.",
+  },
+};

--- a/packages/keychain/src/components/ErrorAlert.tsx
+++ b/packages/keychain/src/components/ErrorAlert.tsx
@@ -69,7 +69,7 @@ export function ErrorAlert({
             <AccordionButton
               disabled={!description || (isExpanded && !allowToggle)}
             >
-              <HStack>
+              <HStack alignItems="flex-start">
                 {(() => {
                   switch (variant) {
                     case "info":

--- a/packages/keychain/src/components/ErrorAlert.tsx
+++ b/packages/keychain/src/components/ErrorAlert.tsx
@@ -87,6 +87,7 @@ export function ErrorAlert({
                   fontSize="2xs"
                   color="inherit"
                   textTransform="uppercase"
+                  align="left"
                 >
                   {title}
                 </Text>

--- a/packages/keychain/src/hooks/upgrade.ts
+++ b/packages/keychain/src/hooks/upgrade.ts
@@ -90,7 +90,7 @@ export const useUpgrade = (controller: Controller): UpgradeInterface => {
     }
 
     return [controller.cartridge.upgrade(LATEST_CONTROLLER.hash)];
-  }, [controller, LATEST_CONTROLLER]);
+  }, [controller]);
 
   const onUpgrade = useCallback(async () => {
     if (!controller || !LATEST_CONTROLLER) {
@@ -110,7 +110,7 @@ export const useUpgrade = (controller: Controller): UpgradeInterface => {
       console.log({ e });
       setError(e);
     }
-  }, [controller, LATEST_CONTROLLER, calls]);
+  }, [controller, calls]);
 
   return {
     available,

--- a/packages/keychain/src/utils/errors.ts
+++ b/packages/keychain/src/utils/errors.ts
@@ -13,7 +13,9 @@ export function parseExecutionError(
     error: string[];
   }[];
 } {
-  let executionError: string = error.data?.execution_error;
+  let executionError: string = (
+    typeof error.data === "string" ? JSON.parse(error.data) : error.data
+  )?.execution_error;
   if (!executionError) {
     return {
       raw: JSON.stringify(error.data),

--- a/packages/keychain/src/utils/errors.ts
+++ b/packages/keychain/src/utils/errors.ts
@@ -148,6 +148,10 @@ export function parseExecutionError(
       } else if (lastErrorMessage === "session/already-registered") {
         summary = "Session already registered";
         lastError[lastError.length - 1] = summary;
+      } else if (
+        /.*Class with hash.*is not declared.$/.test(lastErrorMessage)
+      ) {
+        summary = "Class hash is not declared.";
       } else {
         summary = lastErrorMessage;
         lastError[lastError.length - 1] = summary;


### PR DESCRIPTION
Error stack trace is empty
<img width="493" alt="Screenshot 2024-10-25 at 12 00 25" src="https://github.com/user-attachments/assets/58b1a17d-91f5-49ea-a20e-90a7f4d1bb09">


@tarrencev does the error data type suppose to be`{execution_error: string} | string` or `{execution_error: string}` only or always `string`?

This PR expects the first union. Not sure which I should side adjust either JS side or Rust wasm side.

Also closes #747 