### PR TITLE
Export root index file in connector package

### DIFF
--- a/packages/connector/package.json
+++ b/packages/connector/package.json
@@ -13,6 +13,7 @@
     "format:check": "prettier --check \"src/**/*.ts\""
   },
   "exports": {
+    ".": "./dist/index.js",
     "./controller": "./dist/controller.js",
     "./session": "./dist/session.js",
     "./telegram": "./dist/telegram.js"


### PR DESCRIPTION
This seems required for external Next JS app for some reason.

At least linking this branch locally was the only way I manage to build [dopewars](https://github.com/cartridge-gg/dopewars/pull/385) successfully.