### PR TITLE
Trade Pedersen perf for smaller wasm size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ cainome = { git = "https://github.com/cartridge-gg/cainome", tag = "v0.4.5", fea
 cainome-cairo-serde = { git = "https://github.com/cartridge-gg/cainome", tag = "v0.4.5" }
 
 starknet = "0.12.0"
-starknet-crypto = "0.7.1"
+starknet-crypto = { version = "0.7.3", features = ["pedersen_no_lookup"] }
 starknet-types-core = { version = "0.1", features = ["curve", "hash"] }
 
 # Compiler optimization when running test to prevent ‘locals exceed maximum’ error,


### PR DESCRIPTION
Controller sparingly uses Pedersen hashes. This PR optimizes the account wasm size by removing the Pedersen lookup table by utilizing a new feature in `starknet-crypto` v0.7.3.

This patch removes 126 KB over the wire:

| Build  | Uncompressed (KB) | Transferred w/ gzip (KB) |
| ------ | ----------------- | ------------------------ |
| Before | 1,329             | 593                      |
| After  | 1,149             | 467                      |

Do note that where Pedersen hash _is_ used, it's around 10x as slow as before. Each hash should now take around 1 ms on an average device instead of 0.1 ms.

To put it into perspective, a contract address computation takes `3+ctor_len` number of Pedersen hashes, for example.