### PR TITLE
⚡️ Fetch achievements data at iframe creation

### DIFF
--- a/packages/profile/src/components/app.tsx
+++ b/packages/profile/src/components/app.tsx
@@ -9,8 +9,16 @@ import {
 } from "@/components/inventory";
 import { Trophies } from "@/components/trophies";
 import { Activity } from "@/components/activity";
+import { useAchievements } from "@/hooks/achievements";
+import { useState } from "react";
 
 export function App() {
+  const [accountAddress, setAccountAddress] = useState<string | undefined>(
+    undefined,
+  );
+  // Info: trophies are fetch at the app level to preload them at the iframe creation to improve UX
+  const trophies = useAchievements(accountAddress);
+
   return (
     <Routes>
       <Route path="/" element={null} />
@@ -38,11 +46,15 @@ export function App() {
       />
       <Route
         path="/account/:username/slot/:project/trophies"
-        element={<Trophies />}
+        element={
+          <Trophies trophies={trophies} setAccountAddress={setAccountAddress} />
+        }
       />
       <Route
         path="/account/:username/slot/:project/trophies/:address"
-        element={<Trophies />}
+        element={
+          <Trophies trophies={trophies} setAccountAddress={setAccountAddress} />
+        }
       />
       <Route
         path="/account/:username/slot/:project/activity"

--- a/packages/profile/src/components/app.tsx
+++ b/packages/profile/src/components/app.tsx
@@ -9,16 +9,8 @@ import {
 } from "@/components/inventory";
 import { Trophies } from "@/components/trophies";
 import { Activity } from "@/components/activity";
-import { useAchievements } from "@/hooks/achievements";
-import { useState } from "react";
 
 export function App() {
-  const [accountAddress, setAccountAddress] = useState<string | undefined>(
-    undefined,
-  );
-  // Info: trophies are fetch at the app level to preload them at the iframe creation to improve UX
-  const trophies = useAchievements(accountAddress);
-
   return (
     <Routes>
       <Route path="/" element={null} />
@@ -46,15 +38,11 @@ export function App() {
       />
       <Route
         path="/account/:username/slot/:project/trophies"
-        element={
-          <Trophies trophies={trophies} setAccountAddress={setAccountAddress} />
-        }
+        element={<Trophies />}
       />
       <Route
         path="/account/:username/slot/:project/trophies/:address"
-        element={
-          <Trophies trophies={trophies} setAccountAddress={setAccountAddress} />
-        }
+        element={<Trophies />}
       />
       <Route
         path="/account/:username/slot/:project/activity"

--- a/packages/profile/src/components/context/data.tsx
+++ b/packages/profile/src/components/context/data.tsx
@@ -1,0 +1,32 @@
+import { createContext, useState, ReactNode } from "react";
+import { useAchievements } from "@/hooks/achievements";
+
+type DataContextType = {
+  trophies: ReturnType<typeof useAchievements>;
+  setAccountAddress: (address: string | undefined) => void;
+};
+
+const initialState: DataContextType = {
+  trophies: {
+    achievements: [],
+    players: [],
+    isLoading: false,
+  },
+  setAccountAddress: () => {},
+};
+
+export const DataContext = createContext<DataContextType>(initialState);
+
+export function DataProvider({ children }: { children: ReactNode }) {
+  const [accountAddress, setAccountAddress] = useState<string | undefined>(
+    undefined,
+  );
+
+  const trophies = useAchievements(accountAddress);
+
+  return (
+    <DataContext.Provider value={{ trophies, setAccountAddress }}>
+      {children}
+    </DataContext.Provider>
+  );
+}

--- a/packages/profile/src/components/context/index.tsx
+++ b/packages/profile/src/components/context/index.tsx
@@ -1,3 +1,4 @@
 export { ConnectionContext } from "./connection";
+export { DataContext } from "./data";
 export { ThemeContext } from "./theme";
 export { Provider } from "./provider";

--- a/packages/profile/src/components/context/provider.tsx
+++ b/packages/profile/src/components/context/provider.tsx
@@ -5,6 +5,7 @@ import { ConnectionProvider } from "./connection";
 import { BrowserRouter } from "react-router-dom";
 import { CartridgeAPIProvider } from "@cartridge/utils/api/cartridge";
 import { IndexerAPIProvider } from "@cartridge/utils/api/indexer";
+import { DataProvider } from "./data";
 
 export function Provider({ children }: PropsWithChildren) {
   const queryClient = new QueryClient();
@@ -17,7 +18,9 @@ export function Provider({ children }: PropsWithChildren) {
         >
           <IndexerAPIProvider credentials="omit">
             <QueryClientProvider client={queryClient}>
-              <ConnectionProvider>{children}</ConnectionProvider>
+              <ConnectionProvider>
+                <DataProvider>{children}</DataProvider>
+              </ConnectionProvider>
             </QueryClientProvider>
           </IndexerAPIProvider>
         </CartridgeAPIProvider>

--- a/packages/profile/src/components/trophies/achievements.tsx
+++ b/packages/profile/src/components/trophies/achievements.tsx
@@ -269,7 +269,7 @@ function Page({
 
   const handleMouseLeave = useCallback(() => {
     setHover(false);
-  }, [highlighted]);
+  }, []);
 
   return (
     <div

--- a/packages/profile/src/components/trophies/index.tsx
+++ b/packages/profile/src/components/trophies/index.tsx
@@ -9,24 +9,25 @@ import { TrophiesTab, LeaderboardTab, Scoreboard } from "./tab";
 import { useAccount, useUsername } from "@/hooks/account";
 import { CopyAddress } from "@cartridge/ui-next";
 import { Navigation } from "../navigation";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 import { Achievements } from "./achievements";
 import { Pinneds } from "./pinneds";
 import { Leaderboard } from "./leaderboard";
 import { useAchievements } from "@/hooks/achievements";
-import { useConnection } from "@/hooks/context";
 
-export function Trophies() {
+export function Trophies({
+  trophies: { achievements, players, isLoading },
+  setAccountAddress,
+}: {
+  trophies: ReturnType<typeof useAchievements>;
+  setAccountAddress: (address: string) => void;
+}) {
   const { username: selfname, address: self } = useAccount();
   const location = useLocation();
-  const { namespace } = useConnection();
   const { address } = useParams<{ address: string }>();
   const { username } = useUsername({ address: address || self || "" });
-  const { achievements, players, isLoading } = useAchievements({
-    namespace: namespace ?? "",
-    address: address || self || "",
-  });
+
   const [activeTab, setActiveTab] = useState<"trophies" | "leaderboard">(
     "trophies",
   );
@@ -53,6 +54,10 @@ export function Trophies() {
   const isSelf = useMemo(() => {
     return !address || address === self;
   }, [address, self]);
+
+  useEffect(() => {
+    setAccountAddress(address || self || "");
+  }, [address, self, setAccountAddress]);
 
   return (
     <LayoutContainer

--- a/packages/profile/src/components/trophies/index.tsx
+++ b/packages/profile/src/components/trophies/index.tsx
@@ -14,16 +14,15 @@ import { useParams } from "react-router-dom";
 import { Achievements } from "./achievements";
 import { Pinneds } from "./pinneds";
 import { Leaderboard } from "./leaderboard";
-import { useAchievements } from "@/hooks/achievements";
+import { useData } from "@/hooks/context";
 
-export function Trophies({
-  trophies: { achievements, players, isLoading },
-  setAccountAddress,
-}: {
-  trophies: ReturnType<typeof useAchievements>;
-  setAccountAddress: (address: string) => void;
-}) {
+export function Trophies() {
   const { username: selfname, address: self } = useAccount();
+  const {
+    trophies: { achievements, players, isLoading },
+    setAccountAddress,
+  } = useData();
+
   const location = useLocation();
   const { address } = useParams<{ address: string }>();
   const { username } = useUsername({ address: address || self || "" });

--- a/packages/profile/src/components/trophies/pinneds.tsx
+++ b/packages/profile/src/components/trophies/pinneds.tsx
@@ -5,7 +5,11 @@ export function Pinneds({ achievements }: { achievements: Item[] }) {
   return (
     <div className="grid grid-cols-3 gap-4">
       {achievements.map((achievement) => (
-        <Pinned key={achievement.id} icon={achievement.icon} title={achievement.title} />
+        <Pinned
+          key={achievement.id}
+          icon={achievement.icon}
+          title={achievement.title}
+        />
       ))}
       {Array.from({ length: 3 - achievements.length }).map((_, index) => (
         <Empty key={index} />

--- a/packages/profile/src/components/trophies/pinneds.tsx
+++ b/packages/profile/src/components/trophies/pinneds.tsx
@@ -4,8 +4,8 @@ import { Pinned, Empty } from "./pinned";
 export function Pinneds({ achievements }: { achievements: Item[] }) {
   return (
     <div className="grid grid-cols-3 gap-4">
-      {achievements.map((achievement, index) => (
-        <Pinned key={index} icon={achievement.icon} title={achievement.title} />
+      {achievements.map((achievement) => (
+        <Pinned key={achievement.id} icon={achievement.icon} title={achievement.title} />
       ))}
       {Array.from({ length: 3 - achievements.length }).map((_, index) => (
         <Empty key={index} />

--- a/packages/profile/src/hooks/achievements.ts
+++ b/packages/profile/src/hooks/achievements.ts
@@ -1,8 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { TROPHY, PROGRESS } from "@/constants";
 import { useEvents } from "./events";
 import { Trophy, Progress } from "@/models";
 import { AchievementTask } from "@/components/trophies/achievement";
+import { useConnection } from "./context";
+import { useAccount } from "./account";
 
 // Number of events to fetch at a time, could be increased if needed
 const LIMIT = 1000;
@@ -37,27 +39,28 @@ export interface Player {
   timestamp: number;
 }
 
-export function useAchievements({
-  namespace,
-  address,
-}: {
-  namespace: string;
-  address: string;
-}) {
+export function useAchievements(accountAddress?: string) {
+  const { namespace } = useConnection();
+  const { address } = useAccount();
+
   const [isLoading, setIsLoading] = useState(true);
   const [achievements, setAchievements] = useState<Item[]>([]);
   const [players, setPlayers] = useState<Player[]>([]);
 
+  const currentAddress = useMemo(() => {
+    return accountAddress || address;
+  }, [accountAddress, address]);
+
   const { events: trophies, isFetching: isFetchingTrophiess } =
     useEvents<Trophy>({
-      namespace,
+      namespace: namespace || "",
       name: TROPHY,
       limit: LIMIT,
       parse: Trophy.parse,
     });
   const { events: progresses, isFetching: isFetchingProgresses } =
     useEvents<Progress>({
-      namespace,
+      namespace: namespace || "",
       name: PROGRESS,
       limit: LIMIT,
       parse: Progress.parse,
@@ -69,7 +72,7 @@ export function useAchievements({
       isFetchingTrophiess ||
       isFetchingProgresses ||
       !trophies.length ||
-      !address
+      !currentAddress
     )
       return;
 
@@ -136,7 +139,7 @@ export function useAchievements({
         trophy.tasks.forEach((task) => {
           let count = 0;
           let completion = false;
-          counters[address]?.[task.id]
+          counters[currentAddress]?.[task.id]
             ?.sort((a, b) => a.timestamp - b.timestamp)
             .forEach(
               ({
@@ -183,7 +186,7 @@ export function useAchievements({
     // Update loading state
     setIsLoading(false);
   }, [
-    address,
+    currentAddress,
     trophies,
     progresses,
     isFetchingTrophiess,

--- a/packages/profile/src/hooks/context.ts
+++ b/packages/profile/src/hooks/context.ts
@@ -1,5 +1,9 @@
 import { useContext } from "react";
-import { ThemeContext, ConnectionContext } from "@/components/context";
+import {
+  ThemeContext,
+  ConnectionContext,
+  DataContext,
+} from "@/components/context";
 
 export function useTheme() {
   return useContext(ThemeContext);
@@ -7,4 +11,8 @@ export function useTheme() {
 
 export function useConnection() {
   return useContext(ConnectionContext);
+}
+
+export function useData() {
+  return useContext(DataContext);
 }

--- a/packages/profile/src/hooks/events.ts
+++ b/packages/profile/src/hooks/events.ts
@@ -49,12 +49,11 @@ export function useEvents<TEvent extends Trophy | Progress>({
 }) {
   const { indexerUrl } = useIndexerAPI();
   const [offset, setOffset] = useState(0);
-  const [isFetching, setIsFetching] = useState(true);
   const [nodes, setNodes] = useState<{ [key: string]: boolean }>({});
   const [events, setEvents] = useState<TEvent[]>([]);
 
   // Fetch achievement creations from raw events
-  const { refetch: fetchEvents } = useEventsQuery(
+  const { refetch: fetchEvents, isFetching } = useEventsQuery(
     {
       keys: [
         getSelectorFromName(EVENT_WRAPPER),
@@ -65,12 +64,11 @@ export function useEvents<TEvent extends Trophy | Progress>({
     },
     {
       enabled: false,
+      refetchInterval: 300_000, // Refetch every 5 minutes
       onSuccess: ({ events }: { events: Event }) => {
         // Update offset
         if (events.pageInfo.hasNextPage) {
           setOffset(offset + limit);
-        } else {
-          setIsFetching(false);
         }
         // Parse the events
         const results: TEvent[] = [];

--- a/packages/profile/src/hooks/events.ts
+++ b/packages/profile/src/hooks/events.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Event, EventNode, useEventsQuery } from "@cartridge/utils/api/indexer";
 import { Trophy, Progress } from "@/models";
 import { hash, byteArray, ByteArray } from "starknet";
+import { useIndexerAPI } from "@cartridge/utils";
 
 const EVENT_WRAPPER = "EventEmitted";
 
@@ -46,6 +47,7 @@ export function useEvents<TEvent extends Trophy | Progress>({
   limit: number;
   parse: (node: EventNode) => TEvent;
 }) {
+  const { indexerUrl } = useIndexerAPI();
   const [offset, setOffset] = useState(0);
   const [isFetching, setIsFetching] = useState(true);
   const [nodes, setNodes] = useState<{ [key: string]: boolean }>({});
@@ -85,8 +87,9 @@ export function useEvents<TEvent extends Trophy | Progress>({
   );
 
   useEffect(() => {
+    if (!indexerUrl) return;
     fetchEvents();
-  }, [offset, fetchEvents]);
+  }, [offset, indexerUrl, fetchEvents]);
 
   return { events, isFetching };
 }


### PR DESCRIPTION
Some context:
- When the iframe is instantiated and is hide in the background it loads by default the inventory page, which make the fetch and prepare the view before the user open it
- On the trophy profile page, since it is another page, it is not loaded and takes a bit to be loaded after the user open it
- The purpose of the PR is to call the profile data at the profile app level, so everything is fetched when the iframe is created (I only moved the trophies data so far and leave the tokens inside the page, it could be done in another PR, right now it is already work because the inventory page is active in the background by default)
- I have decided to make a context for this
- I have also added an interval for refetching the event data every 5 minutes but it doesnt really refetch for some reason, gonna address it in another PR