### PR TITLE
More fix for indexer api not ready error

### DIFF
--- a/packages/profile/src/hooks/account.ts
+++ b/packages/profile/src/hooks/account.ts
@@ -3,7 +3,7 @@ import {
   useAccountNameQuery,
   useAddressByUsernameQuery,
 } from "@cartridge/utils/api/cartridge";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useParams } from "react-router-dom";
 
 export function useUsername({ address }: { address: string }) {
@@ -17,16 +17,16 @@ export function useAccount() {
     username: string;
     project?: string;
   }>();
-  const { setIndexerUrl } = useIndexerAPI();
+  const { setIndexerUrl, isReady } = useIndexerAPI();
   const username = params.username ?? "";
   const { data } = useAddressByUsernameQuery(
     { username },
-    { enabled: !!username },
+    { enabled: isReady && !!username },
   );
 
+  const isFirstRender = useRef(true);
   useEffect(() => {
-    if (!params.project) {
-      setIndexerUrl("");
+    if (!params.project || !isFirstRender.current) {
       return;
     }
 
@@ -35,10 +35,14 @@ export function useAccount() {
     }/torii/graphql`;
 
     setIndexerUrl(url);
+    isFirstRender.current = false;
   }, [params.project, setIndexerUrl]);
 
   return {
     username,
-    address: data?.account?.controllers.edges?.[0]?.node?.address ?? "",
+    address:
+      import.meta.env.VITE_MOCKED_ACCOUNT_ADDRESS ??
+      data?.account?.controllers.edges?.[0]?.node?.address ??
+      "",
   };
 }

--- a/packages/profile/src/hooks/events.ts
+++ b/packages/profile/src/hooks/events.ts
@@ -47,7 +47,7 @@ export function useEvents<TEvent extends Trophy | Progress>({
   limit: number;
   parse: (node: EventNode) => TEvent;
 }) {
-  const { indexerUrl } = useIndexerAPI();
+  const { isReady, indexerUrl } = useIndexerAPI();
   const [offset, setOffset] = useState(0);
   const [nodes, setNodes] = useState<{ [key: string]: boolean }>({});
   const [events, setEvents] = useState<TEvent[]>([]);
@@ -63,7 +63,7 @@ export function useEvents<TEvent extends Trophy | Progress>({
       offset,
     },
     {
-      enabled: false,
+      enabled: isReady && false,
       refetchInterval: 300_000, // Refetch every 5 minutes
       onSuccess: ({ events }: { events: Event }) => {
         // Update offset

--- a/packages/profile/src/hooks/username.ts
+++ b/packages/profile/src/hooks/username.ts
@@ -1,7 +1,9 @@
+import { useIndexerAPI } from "@cartridge/utils";
 import { useAccountNameQuery } from "@cartridge/utils/api/cartridge";
 
 export function useUsername({ address }: { address: string }) {
-  const { data } = useAccountNameQuery({ address });
+  const { isReady } = useIndexerAPI();
+  const { data } = useAccountNameQuery({ address }, { enabled: isReady });
 
   return { username: data?.accounts?.edges?.[0]?.node?.username ?? "" };
 }


### PR DESCRIPTION
- Some fixes are slipped from #1066 
- Add `VITE_MOCKED_ACCOUNT_ADDRESS` env to debug profile