### PR TITLE
fix: invalid global controller type definition

### DIFF
--- a/packages/keychain/global.d.ts
+++ b/packages/keychain/global.d.ts
@@ -1,8 +1,8 @@
-import { Controller } from "utils/controller";
+import Controller from "utils/controller";
 
 declare global {
   interface Window {
-    controller: Controller?;
+    controller?: Controller;
   }
 }
 

--- a/packages/keychain/src/utils/connection/estimate.ts
+++ b/packages/keychain/src/utils/connection/estimate.ts
@@ -7,9 +7,9 @@ import {
 
 export function estimateInvokeFee() {
   return async (
-    transactions: Call | Call[],
+    transactions: Call[],
     details?: EstimateFeeDetails,
-  ): Promise<EstimateFee> => {
+  ): Promise<EstimateFee | undefined> => {
     return await window.controller?.estimateInvokeFee(transactions, details);
   };
 }
@@ -18,7 +18,7 @@ export function estimateDeclareFee() {
   return async (
     payload: DeclareContractPayload,
     details?: EstimateFeeDetails,
-  ): Promise<EstimateFee> => {
+  ): Promise<EstimateFee | undefined> => {
     return await window.controller?.estimateDeclareFee(payload, details);
   };
 }

--- a/packages/keychain/src/utils/connection/execute.ts
+++ b/packages/keychain/src/utils/connection/execute.ts
@@ -66,6 +66,12 @@ export function execute({
 
     return await new Promise<InvokeFunctionResponse | ConnectError>(
       async (resolve, reject) => {
+        if (!account) {
+          return reject({
+            message: "Controller context not available",
+          });
+        }
+
         // If a session call and there is no session available
         // fallback to manual apporval flow
         if (!account.hasSession(calls)) {
@@ -123,9 +129,12 @@ export function execute({
             num.addPercent(estimate.overall_fee, ESTIMATE_FEE_PERCENTAGE),
           );
 
-          let { transaction_hash } = await account.execute(transactions, {
-            maxFee,
-          });
+          let { transaction_hash } = await account.execute(
+            transactions as Call[],
+            {
+              maxFee,
+            },
+          );
           return resolve({
             code: ResponseCodes.SUCCESS,
             transaction_hash,


### PR DESCRIPTION
The current `keychain` global `Window` definition is broken in 2 ways:

1. The import `Controller` type should be the default export: ~`{ Controller }`~ -> `Controller`.
2. The `controller` field should be of type `Controller | undefined` instead of `Controller | null`: ~`controller: Controller?`~ -> `controller?: Controller`.

These have been preventing proper type checking for code that involves using `window.controller`, as the compiler treats the invalid declaration to effectively mean `controller: any`. It also makes refactoring much more difficult as things could be silently broken and only surface at runtime.