### PR TITLE
refactor: encapsulate `Controller.cartridge`

### DIFF
--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -84,10 +84,10 @@ export function useConnectionValue() {
   }, [context, parent]);
 
   const setController = useCallback((controller?: Controller) => {
-    if (controller && controller.cartridge && origin) {
-      posthog.identify(controller.cartridge.username(), {
+    if (controller && origin) {
+      posthog.identify(controller.username(), {
         address: controller.address,
-        class: controller.cartridge.classHash,
+        class: controller.classHash(),
         chainId: controller.chainId,
         appId: origin,
       });

--- a/packages/keychain/src/hooks/deploy.ts
+++ b/packages/keychain/src/hooks/deploy.ts
@@ -1,11 +1,10 @@
 import { useCallback, useState } from "react";
-import { num } from "starknet";
 import { useConnection } from "./connection";
 
 type TransactionHash = string;
 
 interface DeployInterface {
-  deploySelf: (maxFee: string) => Promise<TransactionHash>;
+  deploySelf: (maxFee: string) => Promise<TransactionHash | undefined>;
   isDeploying: boolean;
 }
 
@@ -18,9 +17,7 @@ export const useDeploy = (): DeployInterface => {
       if (!controller) return;
       try {
         setIsDeploying(true);
-        const { transaction_hash } = await controller.cartridge.deploySelf(
-          num.toHex(maxFee),
-        );
+        const { transaction_hash } = await controller.selfDeploy(maxFee);
 
         return transaction_hash;
       } catch (e) {

--- a/packages/keychain/src/hooks/upgrade.ts
+++ b/packages/keychain/src/hooks/upgrade.ts
@@ -93,7 +93,7 @@ export const useUpgrade = (controller?: Controller): UpgradeInterface => {
           const current = CONTROLLER_VERSIONS.find(
             (v) =>
               addAddressPadding(v.hash) ===
-              addAddressPadding(controller.cartridge.classHash()),
+              addAddressPadding(controller.classHash()),
           );
           setCurrent(current);
           setAvailable(current?.version !== LATEST_CONTROLLER.version);
@@ -110,7 +110,7 @@ export const useUpgrade = (controller?: Controller): UpgradeInterface => {
       return [];
     }
 
-    return [controller.cartridge.upgrade(LATEST_CONTROLLER.hash)];
+    return [controller.upgrade(LATEST_CONTROLLER.hash)];
   }, [controller]);
 
   const onUpgrade = useCallback(async () => {

--- a/packages/keychain/src/pages/session.tsx
+++ b/packages/keychain/src/pages/session.tsx
@@ -107,7 +107,7 @@ export default function Session() {
       onCallback({
         username: controller.username(),
         address: controller.address,
-        ownerGuid: controller.cartridge.ownerGuid(),
+        ownerGuid: controller.ownerGuid(),
         transactionHash: transaction_hash,
         expiresAt: String(SESSION_EXPIRATION),
       });
@@ -129,7 +129,7 @@ export default function Session() {
       onCallback({
         username: controller.username(),
         address: controller.address,
-        ownerGuid: controller.cartridge.ownerGuid(),
+        ownerGuid: controller.ownerGuid(),
         alreadyRegistered: true,
         expiresAt: String(SESSION_EXPIRATION),
       });

--- a/packages/keychain/src/utils/connection/execute.ts
+++ b/packages/keychain/src/utils/connection/execute.ts
@@ -124,7 +124,7 @@ export function execute({
         }
 
         try {
-          let estimate = await account.cartridge.estimateInvokeFee(calls);
+          let estimate = await account.estimateInvokeFee(calls);
           const maxFee = num.toHex(
             num.addPercent(estimate.overall_fee, ESTIMATE_FEE_PERCENTAGE),
           );

--- a/packages/keychain/src/utils/controller.ts
+++ b/packages/keychain/src/utils/controller.ts
@@ -26,9 +26,10 @@ import {
   SessionMetadata,
 } from "@cartridge/account-wasm/controller";
 import { SessionPolicies } from "@cartridge/presets";
+import { DeployedAccountTransaction } from "@starknet-io/types-js";
 
 export default class Controller extends Account {
-  cartridge: CartridgeAccount;
+  private cartridge: CartridgeAccount;
 
   constructor({
     appId,
@@ -70,6 +71,14 @@ export default class Controller extends Account {
 
   username() {
     return this.cartridge.username();
+  }
+
+  classHash() {
+    return this.cartridge.classHash();
+  }
+
+  ownerGuid() {
+    return this.cartridge.ownerGuid();
   }
 
   rpcUrl() {
@@ -255,6 +264,15 @@ export default class Controller extends Account {
     const release = await mutex.obtain();
     try {
       return await this.cartridge.getNonce();
+    } finally {
+      release();
+    }
+  }
+
+  async selfDeploy(maxFee: BigNumberish): Promise<DeployedAccountTransaction> {
+    const release = await mutex.obtain();
+    try {
+      return await this.cartridge.deploySelf(num.toHex(maxFee));
     } finally {
       release();
     }


### PR DESCRIPTION
The `keychain` codebase currently uses a mix of `Controller` encapsulation and directly accessing `Controller.cartridge`. This is bad and `Controller.cartridge` should just be encapsulated instead to create a unified point of entry to calling anything wasm.

This PR makes the field private and refactors any sites accessing it.