### PR TITLE
fix: unsynchronized concurrent wasm calls

### DIFF
--- a/packages/account-wasm/src/lib.rs
+++ b/packages/account-wasm/src/lib.rs
@@ -5,5 +5,6 @@ pub mod account;
 pub mod session;
 
 mod errors;
+mod sync;
 mod types;
 mod utils;

--- a/packages/account-wasm/src/sync.rs
+++ b/packages/account-wasm/src/sync.rs
@@ -1,0 +1,70 @@
+use std::{
+    ops::{Deref, DerefMut},
+    sync::{Mutex as StdMutex, MutexGuard as StdMutexGuard},
+};
+
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::js_sys::Function;
+
+/// A mutex implementation backed by JavaScript `Promise`s.
+///
+/// This type wraps a simple JavaScript `Mutex` implementation but exposes an idiomatic Rust API.
+pub struct WasmMutex<T> {
+    js_lock: Mutex,
+    rs_lock: StdMutex<T>,
+}
+
+impl<T> WasmMutex<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            js_lock: Mutex::new(),
+            rs_lock: std::sync::Mutex::new(value),
+        }
+    }
+
+    pub async fn lock(&self) -> WasmMutexGuard<T> {
+        WasmMutexGuard {
+            js_release: self.js_lock.obtain().await,
+            // This never actually blocks as it's guarded by the JS lock. This field exists only to
+            // provide internal mutability for the underlying value.
+            rs_guard: self.rs_lock.lock().unwrap(),
+        }
+    }
+}
+
+/// A handle to the underlying guarded value. The lock is released when the instance is dropped.
+pub struct WasmMutexGuard<'a, T> {
+    js_release: Function,
+    rs_guard: StdMutexGuard<'a, T>,
+}
+
+impl<T> Deref for WasmMutexGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        std::sync::MutexGuard::deref(&self.rs_guard)
+    }
+}
+
+impl<T> DerefMut for WasmMutexGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        std::sync::MutexGuard::deref_mut(&mut self.rs_guard)
+    }
+}
+
+impl<T> Drop for WasmMutexGuard<'_, T> {
+    fn drop(&mut self) {
+        self.js_release.call0(&JsValue::null()).unwrap();
+    }
+}
+
+#[wasm_bindgen(module = "/src/wasm-mutex.js")]
+extern "C" {
+    type Mutex;
+
+    #[wasm_bindgen(constructor)]
+    fn new() -> Mutex;
+
+    #[wasm_bindgen(method)]
+    async fn obtain(this: &Mutex) -> Function;
+}

--- a/packages/account-wasm/src/wasm-mutex.js
+++ b/packages/account-wasm/src/wasm-mutex.js
@@ -1,0 +1,13 @@
+function releaseStub() {}
+
+export class Mutex {
+  lastPromise = Promise.resolve();
+
+  async obtain() {
+    let release = releaseStub;
+    const lastPromise = this.lastPromise;
+    this.lastPromise = new Promise((resolve) => (release = resolve));
+    await lastPromise;
+    return release;
+  }
+}

--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -87,7 +87,7 @@ export function useConnectionValue() {
     if (controller) {
       posthog.identify(controller.username(), {
         address: controller.address,
-        class: controller.cartridge.classHash,
+        class: controller.classHash(),
         chainId: controller.chainId,
       });
     } else {

--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -224,12 +224,13 @@ export function useConnectionValue() {
   }, [rpcUrl, controller]);
 
   const logout = useCallback(() => {
-    window.controller?.disconnect();
-    setController(undefined);
+    window.controller?.disconnect().then(() => {
+      setController(undefined);
 
-    context?.resolve?.({
-      code: ResponseCodes.NOT_CONNECTED,
-      message: "User logged out",
+      context?.resolve?.({
+        code: ResponseCodes.NOT_CONNECTED,
+        message: "User logged out",
+      });
     });
   }, [context, setController]);
 

--- a/packages/keychain/src/hooks/deploy.ts
+++ b/packages/keychain/src/hooks/deploy.ts
@@ -1,11 +1,10 @@
 import { useCallback, useState } from "react";
-import { num } from "starknet";
 import { useConnection } from "./connection";
 
 type TransactionHash = string;
 
 interface DeployInterface {
-  deploySelf: (maxFee: string) => Promise<TransactionHash>;
+  deploySelf: (maxFee: string) => Promise<TransactionHash | undefined>;
   isDeploying: boolean;
 }
 
@@ -18,9 +17,7 @@ export const useDeploy = (): DeployInterface => {
       if (!controller) return;
       try {
         setIsDeploying(true);
-        const { transaction_hash } = await controller.cartridge.deploySelf(
-          num.toHex(maxFee),
-        );
+        const { transaction_hash } = await controller.selfDeploy(maxFee);
 
         return transaction_hash;
       } catch (e) {

--- a/packages/keychain/src/hooks/upgrade.ts
+++ b/packages/keychain/src/hooks/upgrade.ts
@@ -93,7 +93,7 @@ export const useUpgrade = (controller?: Controller): UpgradeInterface => {
           const current = CONTROLLER_VERSIONS.find(
             (v) =>
               addAddressPadding(v.hash) ===
-              addAddressPadding(controller.cartridge.classHash()),
+              addAddressPadding(controller.classHash()),
           );
           setCurrent(current);
           setAvailable(current?.version !== LATEST_CONTROLLER.version);
@@ -110,7 +110,7 @@ export const useUpgrade = (controller?: Controller): UpgradeInterface => {
       return [];
     }
 
-    return [controller.cartridge.upgrade(LATEST_CONTROLLER.hash)];
+    return [controller.upgrade(LATEST_CONTROLLER.hash)];
   }, [controller]);
 
   const onUpgrade = useCallback(async () => {

--- a/packages/keychain/src/hooks/upgrade.ts
+++ b/packages/keychain/src/hooks/upgrade.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { JsCall } from "@cartridge/account-wasm";
+import { useCallback, useEffect, useState } from "react";
 import { addAddressPadding, Call } from "starknet";
 import { ControllerError } from "utils/connection";
 import Controller from "utils/controller";
@@ -71,6 +72,7 @@ export const useUpgrade = (controller?: Controller): UpgradeInterface => {
   const [isSynced, setIsSynced] = useState<boolean>(false);
   const [isUpgrading, setIsUpgrading] = useState<boolean>(false);
   const [current, setCurrent] = useState<ControllerVersionInfo>();
+  const [calls, setCalls] = useState<JsCall[]>([]);
 
   useEffect(() => {
     if (!controller) {
@@ -105,12 +107,14 @@ export const useUpgrade = (controller?: Controller): UpgradeInterface => {
       .finally(() => setIsSynced(true));
   }, [controller]);
 
-  const calls = useMemo(() => {
+  useEffect(() => {
     if (!controller || !LATEST_CONTROLLER) {
-      return [];
+      setCalls([]);
+    } else {
+      controller.upgrade(LATEST_CONTROLLER.hash).then((call) => {
+        setCalls([call]);
+      });
     }
-
-    return [controller.upgrade(LATEST_CONTROLLER.hash)];
   }, [controller]);
 
   const onUpgrade = useCallback(async () => {

--- a/packages/keychain/src/pages/index.tsx
+++ b/packages/keychain/src/pages/index.tsx
@@ -12,11 +12,13 @@ import { Upgrade } from "components/connect/Upgrade";
 import { PurchaseCredits } from "components/Funding/PurchaseCredits";
 import { useEffect, useState } from "react";
 import { usePostHog } from "posthog-js/react";
+import { PageLoading } from "components/Loading";
 
 function Home() {
   const { context, controller, error, policies, upgrade } = useConnection();
-  const [hasSessionForPolicies, setHasSessionForPolicies] =
-    useState<boolean>(false);
+  const [hasSessionForPolicies, setHasSessionForPolicies] = useState<
+    boolean | undefined
+  >(undefined);
   const posthog = usePostHog();
 
   useEffect(() => {
@@ -41,7 +43,7 @@ function Home() {
         setHasSessionForPolicies(!!session);
       });
     } else {
-      setHasSessionForPolicies(false);
+      setHasSessionForPolicies(undefined);
     }
   }, [controller, policies]);
 
@@ -85,7 +87,10 @@ function Home() {
         return <></>;
       }
 
-      if (hasSessionForPolicies) {
+      if (hasSessionForPolicies === undefined) {
+        // This is likely never observable in a real application but just in case.
+        return <PageLoading />;
+      } else if (hasSessionForPolicies) {
         context.resolve({
           code: ResponseCodes.SUCCESS,
           address: controller.address,

--- a/packages/keychain/src/pages/index.tsx
+++ b/packages/keychain/src/pages/index.tsx
@@ -10,11 +10,13 @@ import { ErrorPage } from "components/ErrorBoundary";
 import { Settings } from "components/Settings";
 import { Upgrade } from "components/connect/Upgrade";
 import { PurchaseCredits } from "components/Funding/PurchaseCredits";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { usePostHog } from "posthog-js/react";
 
 function Home() {
   const { context, controller, error, policies, upgrade } = useConnection();
+  const [hasSessionForPolicies, setHasSessionForPolicies] =
+    useState<boolean>(false);
   const posthog = usePostHog();
 
   useEffect(() => {
@@ -32,6 +34,16 @@ function Home() {
       });
     }
   }, [context?.origin, posthog]);
+
+  useEffect(() => {
+    if (controller && policies) {
+      controller.session(policies).then((session) => {
+        setHasSessionForPolicies(!!session);
+      });
+    } else {
+      setHasSessionForPolicies(false);
+    }
+  }, [controller, policies]);
 
   if (window.self === window.top || !context?.origin) {
     return <></>;
@@ -73,7 +85,7 @@ function Home() {
         return <></>;
       }
 
-      if (controller.session(policies)) {
+      if (hasSessionForPolicies) {
         context.resolve({
           code: ResponseCodes.SUCCESS,
           address: controller.address,

--- a/packages/keychain/src/pages/session.tsx
+++ b/packages/keychain/src/pages/session.tsx
@@ -125,19 +125,21 @@ export default function Session() {
 
     // If the requested policies has no mismatch with existing policies and public key already
     // registered then return the exising session
-    if (controller.session(policies, queries.public_key)) {
-      onCallback({
-        username: controller.username(),
-        address: controller.address,
-        ownerGuid: controller.ownerGuid(),
-        alreadyRegistered: true,
-        expiresAt: String(SESSION_EXPIRATION),
-      });
+    controller.session(policies, queries.public_key).then((session) => {
+      if (session) {
+        onCallback({
+          username: controller.username(),
+          address: controller.address,
+          ownerGuid: controller.ownerGuid(),
+          alreadyRegistered: true,
+          expiresAt: String(SESSION_EXPIRATION),
+        });
 
-      return;
-    }
+        return;
+      }
 
-    setIsLoading(false);
+      setIsLoading(false);
+    });
   }, [controller, origin, policies, queries.public_key, onCallback]);
 
   if (!controller) {

--- a/packages/keychain/src/pages/session.tsx
+++ b/packages/keychain/src/pages/session.tsx
@@ -107,7 +107,7 @@ export default function Session() {
       onCallback({
         username: controller.username(),
         address: controller.address,
-        ownerGuid: controller.cartridge.ownerGuid(),
+        ownerGuid: controller.ownerGuid(),
         transactionHash: transaction_hash,
         expiresAt: String(SESSION_EXPIRATION),
       });
@@ -129,7 +129,7 @@ export default function Session() {
       onCallback({
         username: controller.username(),
         address: controller.address,
-        ownerGuid: controller.cartridge.ownerGuid(),
+        ownerGuid: controller.ownerGuid(),
         alreadyRegistered: true,
         expiresAt: String(SESSION_EXPIRATION),
       });

--- a/packages/keychain/src/utils/connection/execute.ts
+++ b/packages/keychain/src/utils/connection/execute.ts
@@ -11,6 +11,7 @@ import {
 } from "starknet";
 import { ConnectionCtx, ControllerError, ExecuteCtx } from "./types";
 import { ErrorCode, JsCall } from "@cartridge/account-wasm/controller";
+import { mutex } from "./sync";
 
 export const ESTIMATE_FEE_PERCENTAGE = 10;
 
@@ -64,6 +65,7 @@ export function execute({
       });
     }
 
+    const release = await mutex.obtain();
     return await new Promise<InvokeFunctionResponse | ConnectError>(
       async (resolve, reject) => {
         if (!account) {
@@ -158,7 +160,9 @@ export function execute({
           });
         }
       },
-    );
+    ).finally(() => {
+      release();
+    });
   };
 }
 

--- a/packages/keychain/src/utils/connection/execute.ts
+++ b/packages/keychain/src/utils/connection/execute.ts
@@ -124,7 +124,7 @@ export function execute({
         }
 
         try {
-          let estimate = await account.cartridge.estimateInvokeFee(calls);
+          let estimate = await account.estimateInvokeFee(calls);
           const maxFee = num.toHex(
             num.addPercent(estimate.overall_fee, ESTIMATE_FEE_PERCENTAGE),
           );

--- a/packages/keychain/src/utils/connection/execute.ts
+++ b/packages/keychain/src/utils/connection/execute.ts
@@ -76,7 +76,7 @@ export function execute({
 
         // If a session call and there is no session available
         // fallback to manual apporval flow
-        if (!account.hasSession(calls)) {
+        if (!(await account.hasSession(calls))) {
           setContext({
             type: "execute",
             origin,

--- a/packages/keychain/src/utils/connection/index.ts
+++ b/packages/keychain/src/utils/connection/index.ts
@@ -47,12 +47,14 @@ export function connectToController<ParentMethods extends {}>({
       reset: () => () => setContext(undefined),
       fetchControllers: fetchControllers,
       disconnect: () => () => {
-        window.controller?.disconnect();
-        setController(undefined);
+        window.controller?.disconnect().then(() => {
+          setController(undefined);
+        });
       },
       logout: () => () => {
-        window.controller?.disconnect();
-        setController(undefined);
+        window.controller?.disconnect().then(() => {
+          setController(undefined);
+        });
       },
       username: () => () => window.controller?.username(),
       delegateAccount: () => () => window.controller?.delegateAccount(),

--- a/packages/keychain/src/utils/connection/probe.ts
+++ b/packages/keychain/src/utils/connection/probe.ts
@@ -18,8 +18,9 @@ export function probeFactory({
       }
 
       if (rpcUrl !== controller.rpcUrl()) {
-        controller.disconnect();
-        setController(undefined);
+        controller.disconnect().then(() => {
+          setController(undefined);
+        });
         return Promise.reject({
           code: ResponseCodes.NOT_CONNECTED,
         });

--- a/packages/keychain/src/utils/connection/sign.ts
+++ b/packages/keychain/src/utils/connection/sign.ts
@@ -5,6 +5,7 @@ import {
 } from "@cartridge/controller";
 import { Signature, TypedData } from "starknet";
 import { ConnectionCtx, SignMessageCtx } from "./types";
+import { mutex } from "./sync";
 import Controller from "utils/controller";
 import { parseControllerError } from "./execute";
 
@@ -29,6 +30,7 @@ export function signMessageFactory(setContext: (ctx: ConnectionCtx) => void) {
       });
     }
 
+    const release = await mutex.obtain();
     return await new Promise<Signature | ConnectError>(
       async (resolve, reject) => {
         // If a session call and there is no session available
@@ -62,6 +64,8 @@ export function signMessageFactory(setContext: (ctx: ConnectionCtx) => void) {
           });
         }
       },
-    );
+    ).finally(() => {
+      release();
+    });
   };
 }

--- a/packages/keychain/src/utils/connection/sign.ts
+++ b/packages/keychain/src/utils/connection/sign.ts
@@ -35,7 +35,7 @@ export function signMessageFactory(setContext: (ctx: ConnectionCtx) => void) {
       async (resolve, reject) => {
         // If a session call and there is no session available
         // fallback to manual apporval flow
-        if (!controller.hasSessionForMessage(typedData)) {
+        if (!(await controller.hasSessionForMessage(typedData))) {
           setContext({
             type: "sign-message",
             origin,

--- a/packages/keychain/src/utils/connection/sync.ts
+++ b/packages/keychain/src/utils/connection/sync.ts
@@ -1,0 +1,3 @@
+import { Mutex } from "utils/mutex";
+
+export const mutex = new Mutex();

--- a/packages/keychain/src/utils/controller.ts
+++ b/packages/keychain/src/utils/controller.ts
@@ -26,9 +26,10 @@ import {
   SessionMetadata,
 } from "@cartridge/account-wasm/controller";
 import { SessionPolicies } from "@cartridge/presets";
+import { DeployedAccountTransaction } from "@starknet-io/types-js";
 
 export default class Controller extends Account {
-  cartridge: CartridgeAccount;
+  private cartridge: CartridgeAccount;
 
   constructor({
     appId,
@@ -70,6 +71,14 @@ export default class Controller extends Account {
 
   username() {
     return this.cartridge.username();
+  }
+
+  classHash() {
+    return this.cartridge.classHash();
+  }
+
+  ownerGuid() {
+    return this.cartridge.ownerGuid();
   }
 
   rpcUrl() {
@@ -255,6 +264,15 @@ export default class Controller extends Account {
     const release = await mutex.obtain();
     try {
       return await this.cartridge.getNonce();
+    } finally {
+      release();
+    }
+  }
+
+  async selfDeploy(maxFee: BigNumberish): Promise<DeployedAccountTransaction> {
+    const release = await mutex.obtain();
+    try {
+      return await this.cartridge.deploySelf(num.toHex(maxFee));
     } finally {
       release();
     }

--- a/packages/keychain/src/utils/controller.ts
+++ b/packages/keychain/src/utils/controller.ts
@@ -92,8 +92,8 @@ export default class Controller extends Account {
     return this.cartridgeMeta.chainId();
   }
 
-  disconnect() {
-    this.cartridge.disconnect();
+  async disconnect() {
+    await this.cartridge.disconnect();
     delete window.controller;
   }
 
@@ -109,12 +109,12 @@ export default class Controller extends Account {
     await this.cartridge.createSession(toWasmPolicies(policies), expiresAt);
   }
 
-  registerSessionCalldata(
+  async registerSessionCalldata(
     expiresAt: bigint,
     policies: SessionPolicies,
     publicKey: string,
-  ): Array<string> {
-    return this.cartridge.registerSessionCalldata(
+  ): Promise<Array<string>> {
+    return await this.cartridge.registerSessionCalldata(
       toWasmPolicies(policies),
       expiresAt,
       publicKey,
@@ -139,8 +139,8 @@ export default class Controller extends Account {
     );
   }
 
-  upgrade(new_class_hash: JsFelt): JsCall {
-    return this.cartridge.upgrade(new_class_hash);
+  async upgrade(new_class_hash: JsFelt): Promise<JsCall> {
+    return await this.cartridge.upgrade(new_class_hash);
   }
 
   async executeFromOutsideV2(calls: Call[]): Promise<InvokeFunctionResponse> {
@@ -169,19 +169,19 @@ export default class Controller extends Account {
     );
   }
 
-  hasSession(calls: Call[]): boolean {
-    return this.cartridge.hasSession(toJsCalls(calls));
+  async hasSession(calls: Call[]): Promise<boolean> {
+    return await this.cartridge.hasSession(toJsCalls(calls));
   }
 
-  hasSessionForMessage(typedData: TypedData): boolean {
-    return this.cartridge.hasSessionForMessage(JSON.stringify(typedData));
+  async hasSessionForMessage(typedData: TypedData): Promise<boolean> {
+    return await this.cartridge.hasSessionForMessage(JSON.stringify(typedData));
   }
 
-  session(
+  async session(
     policies: SessionPolicies,
     public_key?: string,
-  ): SessionMetadata | undefined {
-    return this.cartridge.session(toWasmPolicies(policies), public_key);
+  ): Promise<SessionMetadata | undefined> {
+    return await this.cartridge.session(toWasmPolicies(policies), public_key);
   }
 
   async estimateInvokeFee(


### PR DESCRIPTION
Concurrent calls to the wasm module where at least one call borrows `CartridgeAccount` mutably causes `wasm-bindgen`'s runtime borrow checker to throw:

```
recursive use of an object detected which would lead to unsafe aliasing in rust
```

This PR fixes it by:

1. Reducing unnecessary borrowing: A new `CartridgeAccountWithMeta` type is now used for reading fixed values. This type is only ever borrowed immutably, so concurrent accesses are fine.
2. Guarding the inner `controller` value with a Promise-backed `WasmMutex`, and changing all entrypoint signatures to use `&self` instead of `&mut self`.

> [!NOTE]
>
> Using a mutex for all calls, as implemented in this PR, is an overkill. A more ideal implementation would be something like a `RwLock` such that concurrent reads are still allowed.