### PR TITLE
Temporarily allow logins for usernames with periods

### DIFF
--- a/packages/keychain/src/components/connect/create/useUsernameValidation.ts
+++ b/packages/keychain/src/components/connect/create/useUsernameValidation.ts
@@ -37,7 +37,8 @@ export function useUsernameValidation(username: string) {
         return;
       }
 
-      if (!/^[a-zA-Z0-9-]+$/.test(username)) {
+      // TEMP: allow periods for login and disabllow for signup below
+      if (!/^[a-zA-Z0-9-.]+$/.test(username)) {
         setValidation({
           status: "invalid",
           error: new Error(
@@ -74,6 +75,17 @@ export function useUsernameValidation(username: string) {
         if (controller.signal.aborted) return;
 
         if (e.message === "ent: account not found") {
+          // TEMP: disallow periods for signup
+          if (username.includes(".")) {
+            setValidation({
+              status: "invalid",
+              error: new Error(
+                "Username can only contain letters, numbers, and hyphens",
+              ),
+            });
+            return;
+          }
+
           setValidation({
             status: "valid",
             exists: false,


### PR DESCRIPTION
We have some controller accounts that were created with periods but now disallowed for login. This PR allows them to login again to transfer their assets out of the controller.