### PR TITLE
Add chain-id to account storage key

### DIFF
--- a/packages/account_sdk/src/controller.rs
+++ b/packages/account_sdk/src/controller.rs
@@ -99,6 +99,7 @@ impl Controller {
             .storage
             .set_controller(
                 app_id.as_str(),
+                &chain_id,
                 address,
                 ControllerMetadata::from(&controller),
             )

--- a/packages/account_sdk/src/storage/selectors.rs
+++ b/packages/account_sdk/src/storage/selectors.rs
@@ -7,8 +7,8 @@ impl Selectors {
         format!("@cartridge/{}/active", app_id)
     }
 
-    pub fn account(address: &Felt) -> String {
-        format!("@cartridge/account/0x{:x}", address)
+    pub fn account(address: &Felt, chain_id: &Felt) -> String {
+        format!("@cartridge/account/0x{:x}/0x{:x}", address, chain_id)
     }
 
     pub fn deployment(address: &Felt, chain_id: &Felt) -> String {


### PR DESCRIPTION
This will help with multi accounts/networks support by using the chain id as an additional key to `account` in local storage.