### PR TITLE
Fix parsing chain id from slot rpcUrl

### DIFF
--- a/packages/controller/src/controller.ts
+++ b/packages/controller/src/controller.ts
@@ -46,9 +46,13 @@ export default class ControllerProvider extends BaseProvider {
       } else if (parts.length >= 3) {
         const projectName = parts[2];
         if (parts.includes("katana")) {
-          chainId = `WP_${projectName.toUpperCase()}` as ChainId;
+          chainId = `WP_${projectName
+            .toUpperCase()
+            .replace(/-/g, "_")}` as ChainId;
         } else if (parts.includes("mainnet")) {
-          chainId = `GG_${projectName.toUpperCase()}` as ChainId;
+          chainId = `GG_${projectName
+            .toUpperCase()
+            .replace(/-/g, "_")}` as ChainId;
         }
       }
 


### PR DESCRIPTION
Example `https://api.cartridge.gg/x/nums-slot/katana` chain id should be `WP_NUMS_SLOT`