### PR TITLE
Prevent storybook to open in browser

### DIFF
--- a/packages/keychain/package.json
+++ b/packages/keychain/package.json
@@ -13,7 +13,7 @@
     "format:check": "prettier --check --ignore-path .gitignore .",
     "test": "vitest",
     "test:ci": "vitest run",
-    "storybook": "storybook dev -p 6001",
+    "storybook": "storybook dev -p 6001 --no-open",
     "storybook:build": "storybook build",
     "storybook:serve": "pnpm storybook:build --quiet && pnpm http-server -c-1 storybook-static --port 6006 --silent",
     "test-storybook": "test-storybook --testTimeout=60000",

--- a/packages/ui-next/package.json
+++ b/packages/ui-next/package.json
@@ -27,7 +27,7 @@
     "format": "prettier --write ./src",
     "format:check": "prettier --check ./src",
     "lint": "eslint .",
-    "storybook": "storybook dev -p 6003",
+    "storybook": "storybook dev -p 6003 --no-open",
     "storybook:build": "storybook build",
     "storybook:serve": "pnpm storybook:build --quiet && pnpm http-server -c-1 storybook-static --port 6007 --silent",
     "test-storybook": "test-storybook",


### PR DESCRIPTION
It's a bit annoying that storybook is automatically open in the new tab in the browser every time running `pnpm storybook` even the tab already exists.