### PR TITLE
Avoid conflict with reserved pnpm subcommand by spelling profile in French

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "account-wasm": "pnpm --filter @cartridge/account-wasm",
     "book": "pnpm --filter @cartridge/documentation",
     "ui:next": "pnpm --filter @cartridge/ui-next",
-    "profile": "pnpm --filter @cartridge/profile",
+    "profil": "pnpm --filter @cartridge/profile",
     "utils": "pnpm --filter @cartridge/utils",
     "example:next": "pnpm --filter @cartridge/controller-example-next",
     "example:svelte": "pnpm --filter @cartridge/controller-example-svelte",


### PR DESCRIPTION
`pnpm profile` is a reserved subcommand

```sh
🦄  pnpm profile -h
Change settings on your registry profile

Usage:
npm profile enable-2fa [auth-only|auth-and-writes]
npm profile disable-2fa
npm profile get [<key>]
npm profile set <key> <value>

Options:
[--registry <registry>] [--json] [-p|--parseable] [--otp <otp>]

Run "npm help profile" for more info
```