### PR TITLE
Session expiration use fixed timestamp

### DIFF
--- a/packages/keychain/src/components/connect/CreateSession.tsx
+++ b/packages/keychain/src/components/connect/CreateSession.tsx
@@ -9,7 +9,7 @@ import { Upgrade } from "./Upgrade";
 import { ParsedSessionPolicies } from "@/hooks/session";
 import { UnverifiedSessionSummary } from "@/components/session/UnverifiedSessionSummary";
 import { VerifiedSessionSummary } from "@/components/session/VerifiedSessionSummary";
-import { DEFAULT_SESSION_DURATION } from "@/const";
+import { DEFAULT_SESSION_DURATION, NOW } from "@/const";
 import { Button, Checkbox } from "@cartridge/ui-next";
 
 export function CreateSession({
@@ -18,7 +18,7 @@ export function CreateSession({
   isUpdate,
 }: {
   policies: ParsedSessionPolicies;
-  onConnect: (transaction_hash?: string) => void;
+  onConnect: (transaction_hash?: string, expiresAt?: bigint) => void;
   isUpdate?: boolean;
 }) {
   const { controller, upgrade, chainId, theme, logout } = useConnection();
@@ -27,6 +27,9 @@ export function CreateSession({
   const [duration, setDuration] = useState<bigint>(DEFAULT_SESSION_DURATION);
   const [maxFee] = useState<BigNumberish>();
   const [error, setError] = useState<ControllerError | Error>();
+  const expiresAt = useMemo(() => {
+    return duration + NOW;
+  }, [duration]);
 
   const chainSpecificMessages = useMemo(() => {
     if (!policies.messages || !chainId) return [];
@@ -64,7 +67,7 @@ export function CreateSession({
         });
       }
 
-      await controller.createSession(duration, policies, maxFee);
+      await controller.createSession(expiresAt, policies, maxFee);
       onConnect();
     } catch (e) {
       setError(e as unknown as Error);

--- a/packages/keychain/src/components/connect/RegisterSession.tsx
+++ b/packages/keychain/src/components/connect/RegisterSession.tsx
@@ -1,5 +1,5 @@
 import { Content } from "@/components/layout";
-import { useCallback, useState, useEffect } from "react";
+import { useCallback, useState, useEffect, useMemo } from "react";
 import { useConnection } from "@/hooks/connection";
 import { SessionConsent } from "@/components/connect";
 import { ExecutionContainer } from "@/components/ExecutionContainer";
@@ -18,7 +18,7 @@ export function RegisterSession({
   publicKey,
 }: {
   policies: ParsedSessionPolicies;
-  onConnect: (transaction_hash?: string) => void;
+  onConnect: (transaction_hash: string, expiresAt: bigint) => void;
   publicKey?: string;
 }) {
   const { controller, theme } = useConnection();
@@ -32,7 +32,9 @@ export function RegisterSession({
     | undefined
   >(undefined);
 
-  const expiresAt = NOW + duration;
+  const expiresAt = useMemo(() => {
+    return duration + NOW;
+  }, [duration]);
 
   useEffect(() => {
     if (!publicKey || !controller) {
@@ -91,7 +93,7 @@ export function RegisterSession({
         ],
       });
 
-      onConnect(transaction_hash);
+      onConnect(transaction_hash, expiresAt);
     },
     [controller, expiresAt, policies, publicKey, onConnect],
   );

--- a/packages/keychain/src/components/session.tsx
+++ b/packages/keychain/src/components/session.tsx
@@ -9,7 +9,6 @@ import {
 import { useConnection } from "@/hooks/connection";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { LoginMode } from "@/components/connect/types";
-import { SESSION_EXPIRATION } from "@/const";
 import { PageLoading } from "@/components/Loading";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
@@ -110,7 +109,7 @@ export function Session() {
 
   // Handler when user clicks the Create button
   const onConnect = useCallback(
-    async (transaction_hash?: string) => {
+    async (transaction_hash?: string, expiresAt?: bigint) => {
       if (!queries.callback_uri && !queries.redirect_uri) {
         throw new Error("Expected either callback_uri or redirect_uri");
       }
@@ -122,7 +121,7 @@ export function Session() {
         address: controller.address,
         ownerGuid: controller.ownerGuid(),
         transactionHash: transaction_hash,
-        expiresAt: String(SESSION_EXPIRATION),
+        expiresAt: String(expiresAt),
       });
     },
     [queries.callback_uri, queries.redirect_uri, controller, onCallback],

--- a/packages/keychain/src/const.ts
+++ b/packages/keychain/src/const.ts
@@ -1,4 +1,3 @@
 export const CARTRIDGE_DISCORD_LINK = "https://discord.gg/cartridge";
 export const DEFAULT_SESSION_DURATION = BigInt(7 * 24 * 60 * 60);
 export const NOW = BigInt(Math.floor(Date.now() / 1000));
-export const SESSION_EXPIRATION = NOW + DEFAULT_SESSION_DURATION; // 1 week

--- a/packages/keychain/src/utils/controller.ts
+++ b/packages/keychain/src/utils/controller.ts
@@ -101,7 +101,7 @@ export default class Controller extends Account {
   }
 
   async createSession(
-    duration: bigint,
+    expiresAt: bigint,
     policies: ParsedSessionPolicies,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _maxFee?: BigNumberish,
@@ -110,7 +110,6 @@ export default class Controller extends Account {
       throw new Error("Account not found");
     }
 
-    const expiresAt = duration + BigInt(Math.floor(Date.now() / 1000));
     await this.cartridge.createSession(toWasmPolicies(policies), expiresAt);
   }
 
@@ -127,7 +126,7 @@ export default class Controller extends Account {
   }
 
   async registerSession(
-    duration: bigint,
+    expiresAt: bigint,
     policies: ParsedSessionPolicies,
     publicKey: string,
     maxFee: BigNumberish,
@@ -135,8 +134,6 @@ export default class Controller extends Account {
     if (!this.cartridge) {
       throw new Error("Account not found");
     }
-
-    const expiresAt = duration + BigInt(Math.floor(Date.now() / 1000));
 
     return await this.cartridge.registerSession(
       toWasmPolicies(policies),


### PR DESCRIPTION
This PR fixes `('session/not-registered')` when sending transaction with remote session
* Use const NOW timestamp instead of `Date.now()`
* Local storage using hardcoded default expiration