### PR TITLE
Fix backgrounnd color in ErrorBoundary

### DIFF
--- a/packages/keychain/src/components/ErrorBoundary.tsx
+++ b/packages/keychain/src/components/ErrorBoundary.tsx
@@ -58,7 +58,7 @@ export function ErrorPage({ error }: { error: Error }) {
         chainId={chainId}
       />
       <LayoutContent className="gap-4">
-        <div className="flex w-full px-4 py-6 bg-secondary border border-background-200 rounded">
+        <div className="flex w-full px-4 py-6 bg-background-100 border border-background-200 rounded">
           <p className="w-full text-sm">{error.message}</p>
         </div>
 


### PR DESCRIPTION
Fix background color where old theme name was applied

Before:
<img width="448" alt="Screenshot 2025-02-01 at 11 21 49" src="https://github.com/user-attachments/assets/7e2f4a82-d5dc-4912-bf9a-02d5e986e019" />