### PR TITLE
Migrate ui to subpath imports

### DIFF
--- a/packages/ui-next/components.json
+++ b/packages/ui-next/components.json
@@ -11,8 +11,8 @@
     "prefix": ""
   },
   "aliases": {
-    "components": "@/components",
-    "utils": "@/utils",
-    "ui": "@/components/primitives"
+    "components": "#components",
+    "utils": "#utils",
+    "ui": "#components/primitives"
   }
 }

--- a/packages/ui-next/package.json
+++ b/packages/ui-next/package.json
@@ -25,8 +25,17 @@
     "./themes/fonts.css": "./dist/themes/fonts.css",
     "./themes/scrollbar.css": "./dist/themes/scrollbar.css"
   },
+  "imports": {
+    "#*": [
+      "./src/*",
+      "./src/*.ts",
+      "./src/*.tsx",
+      "./src/*/index.ts",
+      "./src/*/index.tsx"
+    ]
+  },
   "scripts": {
-    "build:deps": "tsc && tsc-alias && pnpm copyThemes",
+    "build:deps": "tsc && pnpm copyThemes",
     "copyThemes": "rm -rf dist/themes && cp -R src/themes dist/themes",
     "format": "prettier --write ./src",
     "format:check": "prettier --check ./src",
@@ -95,7 +104,6 @@
     "start-server-and-test": "catalog:",
     "storybook": "catalog:",
     "tailwindcss": "catalog:",
-    "tsc-alias": "^1.8.10",
     "typescript": "catalog:",
     "vite": "catalog:"
   },

--- a/packages/ui-next/src/components/copy-address.tsx
+++ b/packages/ui-next/src/components/copy-address.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/utils";
+import { cn } from "#utils";
 import { formatAddress, FormatAddressOptions } from "@cartridge/utils";
 import { CopyIcon } from "./icons";
 import { toast } from "sonner";

--- a/packages/ui-next/src/components/copy-text.tsx
+++ b/packages/ui-next/src/components/copy-text.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/utils";
+import { cn } from "#utils";
 import { CopyIcon } from "./icons";
 import { toast } from "sonner";
 import { useCallback } from "react";

--- a/packages/ui-next/src/components/error-image.tsx
+++ b/packages/ui-next/src/components/error-image.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/utils";
+import { cn } from "#utils";
 import { forwardRef } from "react";
 import { memo } from "react";
 

--- a/packages/ui-next/src/components/icons/error-alert-icon.tsx
+++ b/packages/ui-next/src/components/icons/error-alert-icon.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/utils";
+import { cn } from "#utils";
 import { InfoIcon, WarningIcon, AlertIcon as AlertIconRaw } from "./utility";
 
 export type ErrorAlertIconProps = {

--- a/packages/ui-next/src/components/icons/utility/magnifying-glass.tsx
+++ b/packages/ui-next/src/components/icons/utility/magnifying-glass.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, memo } from "react";
 import { iconVariants } from "../utils";
 import { IconProps } from "../types";
-import { cn } from "@/utils";
+import { cn } from "#utils";
 
 export const MagnifyingGlassIcon = memo(
   forwardRef<SVGSVGElement, IconProps>(

--- a/packages/ui-next/src/components/icons/utility/slash.tsx
+++ b/packages/ui-next/src/components/icons/utility/slash.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, memo } from "react";
 import { iconVariants } from "../utils";
 import { IconProps } from "../types";
-import { cn } from "@/utils";
+import { cn } from "#utils";
 
 export const SlashIcon = memo(
   forwardRef<SVGSVGElement, IconProps>(

--- a/packages/ui-next/src/components/layout/bottom-tabs.stories.tsx
+++ b/packages/ui-next/src/components/layout/bottom-tabs.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { LayoutBottomTabs, layoutBottomTabsVariants } from "./index";
-import { BottomTab } from "@/index";
+import { BottomTab } from "#components/primitives";
 import {
   ChestIcon,
   ClockIcon,
@@ -8,8 +7,9 @@ import {
   SwordsIcon,
   TrophyIcon,
   UsersIcon,
-} from "../icons";
-import { cn } from "@/utils";
+} from "#components/icons";
+import { LayoutBottomTabs, layoutBottomTabsVariants } from "#components/layout";
+import { cn } from "#utils";
 
 const meta: Meta<typeof LayoutBottomTabs> = {
   title: "Layout/BottomTabs",

--- a/packages/ui-next/src/components/layout/container.tsx
+++ b/packages/ui-next/src/components/layout/container.tsx
@@ -1,25 +1,8 @@
-import { cn } from "@/utils";
+import { useMediaQuery } from "#hooks/ui";
+import { cn } from "#utils";
 import { isIframe } from "@cartridge/utils";
-import { type PropsWithChildren, useEffect, useState } from "react";
+import { type PropsWithChildren, useState } from "react";
 import { LayoutContext } from "./context";
-
-export function useMediaQuery(query: string) {
-  const [matches, setMatches] = useState(false);
-
-  useEffect(() => {
-    const media = window.matchMedia(query);
-    setMatches(media.matches);
-
-    const listener = (e: MediaQueryListEvent) => {
-      setMatches(e.matches);
-    };
-
-    media.addEventListener("change", listener);
-    return () => media.removeEventListener("change", listener);
-  }, [query]);
-
-  return matches;
-}
 
 export function LayoutContainer({
   children,

--- a/packages/ui-next/src/components/layout/header.tsx
+++ b/packages/ui-next/src/components/layout/header.tsx
@@ -8,20 +8,20 @@ import {
   StarknetColorIcon,
   StarknetIcon,
   TimesIcon,
-} from "@/components/icons";
+} from "#components/icons";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "@/components/primitives/tooltip";
-import { cn } from "@/utils";
-import { Button } from "@/components/primitives/button";
+} from "#components/primitives/tooltip";
+import { cn } from "#utils";
+import { Button } from "#components/primitives/button";
 import { getChainName, isIframe, isSlotChain } from "@cartridge/utils";
 import { constants } from "starknet";
 import { CopyAddress } from "../copy-address";
-import { Network } from "@/components/network";
-import { useUI } from "@/hooks";
+import { Network } from "#components/network";
+import { useUI } from "#hooks";
 
 export type HeaderProps = HeaderInnerProps & {
   onBack?: () => void;

--- a/packages/ui-next/src/components/modules/achievements/bit/bit.tsx
+++ b/packages/ui-next/src/components/modules/achievements/bit/bit.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/index";
+import { cn } from "#utils";
 
 interface AchievementBitProps {
   completed?: boolean;
@@ -22,5 +22,3 @@ export function AchievementBit({
     />
   );
 }
-
-export default AchievementBit;

--- a/packages/ui-next/src/components/modules/achievements/bits/bits.tsx
+++ b/packages/ui-next/src/components/modules/achievements/bits/bits.tsx
@@ -12,5 +12,3 @@ export function AchievementBits({ ...props }: AchievementBitsProps) {
     </div>
   );
 }
-
-export default AchievementBits;

--- a/packages/ui-next/src/components/modules/achievements/card/card.tsx
+++ b/packages/ui-next/src/components/modules/achievements/card/card.tsx
@@ -1,18 +1,11 @@
-import {
-  AchievementBit,
-  AchievementBits,
-  AchievementContent,
-  AchievementContentProps,
-  AchievementPagination,
-  AchievementPin,
-  AchievementPinProps,
-  AchievementShare,
-  AchievementShareProps,
-  Card,
-  CardHeader,
-  CardTitle,
-  cn,
-} from "@/index";
+import { Card, CardHeader, CardTitle } from "#components/primitives";
+import { cn } from "#utils";
+import { AchievementBit } from "../bit";
+import { AchievementBits } from "../bits";
+import { AchievementContent, AchievementContentProps } from "../content";
+import { AchievementPagination } from "../pagination";
+import { AchievementPin, AchievementPinProps } from "../pin";
+import { AchievementShare, AchievementShareProps } from "../share";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 export interface AchievementCardProps
@@ -123,5 +116,3 @@ export const AchievementCard = ({
     </Card>
   );
 };
-
-export default AchievementCard;

--- a/packages/ui-next/src/components/modules/achievements/content/content.tsx
+++ b/packages/ui-next/src/components/modules/achievements/content/content.tsx
@@ -1,9 +1,6 @@
-import {
-  AchievementLabel,
-  AchievementTask,
-  AchievementTaskProps,
-  CardContent,
-} from "@/index";
+import { CardContent } from "#components/primitives";
+import { AchievementLabel } from "../label";
+import { AchievementTask, AchievementTaskProps } from "../task";
 import { useMemo } from "react";
 
 export interface AchievementContentProps {
@@ -54,5 +51,3 @@ export function AchievementContent({
     </CardContent>
   );
 }
-
-export default AchievementContent;

--- a/packages/ui-next/src/components/modules/achievements/counter/counter.tsx
+++ b/packages/ui-next/src/components/modules/achievements/counter/counter.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/index";
+import { cn } from "#utils";
 
 export interface AchievementCounterProps {
   count: number;
@@ -32,5 +32,3 @@ export const AchievementCounter = ({
     </div>
   );
 };
-
-export default AchievementCounter;

--- a/packages/ui-next/src/components/modules/achievements/featured/featured.tsx
+++ b/packages/ui-next/src/components/modules/achievements/featured/featured.tsx
@@ -1,5 +1,6 @@
-import { cn, Card, CardHeader, CardTitle } from "@/index";
 import { useMemo } from "react";
+import { Card, CardHeader, CardTitle } from "#components/primitives";
+import { cn } from "#utils";
 
 interface AchievementFeaturedProps {
   icon?: string;
@@ -61,5 +62,3 @@ export function Banner() {
     </div>
   );
 }
-
-export default AchievementFeatured;

--- a/packages/ui-next/src/components/modules/achievements/icon/icon.tsx
+++ b/packages/ui-next/src/components/modules/achievements/icon/icon.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/index";
+import { cn } from "#utils";
 
 interface AchievementIconProps {
   icon?: string;
@@ -17,5 +17,3 @@ export function AchievementIcon({ icon, completed }: AchievementIconProps) {
     </div>
   );
 }
-
-export default AchievementIcon;

--- a/packages/ui-next/src/components/modules/achievements/label/label.tsx
+++ b/packages/ui-next/src/components/modules/achievements/label/label.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/index";
+import { cn } from "#utils";
 import { AchievementIcon } from "../icon";
 import { AchievementPoints } from "../points";
 
@@ -51,5 +51,3 @@ export function AchievementTitle({
     </p>
   );
 }
-
-export default AchievementLabel;

--- a/packages/ui-next/src/components/modules/achievements/leaderboard-counter/leaderboard-counter.tsx
+++ b/packages/ui-next/src/components/modules/achievements/leaderboard-counter/leaderboard-counter.tsx
@@ -1,4 +1,5 @@
-import { cn, LeaderboardIcon } from "@/index";
+import { LeaderboardIcon } from "#components/icons";
+import { cn } from "#utils";
 
 export interface AchievementLeaderboardCounterProps {
   rank: number;
@@ -35,5 +36,3 @@ export const AchievementLeaderboardCounter = ({
     </div>
   );
 };
-
-export default AchievementLeaderboardCounter;

--- a/packages/ui-next/src/components/modules/achievements/leaderboard-row/leaderboard-row.tsx
+++ b/packages/ui-next/src/components/modules/achievements/leaderboard-row/leaderboard-row.tsx
@@ -1,7 +1,8 @@
-import { cn, SparklesIcon } from "@/index";
+import { cn } from "#utils";
+import { SparklesIcon } from "#components/icons";
 import { useEffect, useRef, useState } from "react";
 import { AchievementPinIcons } from "../pin-icons";
-import AchievementLeaderboardUsername from "../leaderboard-username/leaderboard-username";
+import { AchievementLeaderboardUsername } from "../leaderboard-username/leaderboard-username";
 
 export interface AchievementLeaderboardRowProps
   extends React.HTMLAttributes<HTMLDivElement> {
@@ -84,5 +85,3 @@ export const AchievementLeaderboardRow = ({
     </div>
   );
 };
-
-export default AchievementLeaderboardRow;

--- a/packages/ui-next/src/components/modules/achievements/leaderboard-username/leaderboard-username.tsx
+++ b/packages/ui-next/src/components/modules/achievements/leaderboard-username/leaderboard-username.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/index";
+import { cn } from "#utils";
 
 export interface AchievementLeaderboardUsernameProps {
   username: string;
@@ -28,5 +28,3 @@ export const AchievementLeaderboardUsername = ({
     </div>
   );
 };
-
-export default AchievementLeaderboardUsername;

--- a/packages/ui-next/src/components/modules/achievements/leaderboard/leaderboard.stories.tsx
+++ b/packages/ui-next/src/components/modules/achievements/leaderboard/leaderboard.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { AchievementLeaderboard } from "./leaderboard";
-import AchievementLeaderboardRow from "../leaderboard-row/leaderboard-row";
+import { AchievementLeaderboardRow } from "../leaderboard-row/leaderboard-row";
 
 const meta: Meta<typeof AchievementLeaderboard> = {
   title: "Modules/Achievements/Leaderboard",

--- a/packages/ui-next/src/components/modules/achievements/leaderboard/leaderboard.tsx
+++ b/packages/ui-next/src/components/modules/achievements/leaderboard/leaderboard.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/index";
+import { cn } from "#utils";
 
 export const AchievementLeaderboard = ({
   className,
@@ -17,5 +17,3 @@ export const AchievementLeaderboard = ({
     />
   );
 };
-
-export default AchievementLeaderboard;

--- a/packages/ui-next/src/components/modules/achievements/pagination/pagination.tsx
+++ b/packages/ui-next/src/components/modules/achievements/pagination/pagination.tsx
@@ -1,4 +1,5 @@
-import { Button, WedgeIcon } from "@/index";
+import { Button } from "#components/primitives";
+import { WedgeIcon } from "#components/icons";
 
 interface AchievementPaginationProps {
   direction: "left" | "right";
@@ -27,5 +28,3 @@ export function AchievementPagination({
     </Button>
   );
 }
-
-export default AchievementPagination;

--- a/packages/ui-next/src/components/modules/achievements/pin-icon/pin-icon.tsx
+++ b/packages/ui-next/src/components/modules/achievements/pin-icon/pin-icon.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/index";
+import { cn } from "#utils";
 import { cva, VariantProps } from "class-variance-authority";
 
 const achievementPinIconVariants = cva(
@@ -57,5 +57,3 @@ export const AchievementPinIcon = ({
     </div>
   );
 };
-
-export default AchievementPinIcon;

--- a/packages/ui-next/src/components/modules/achievements/pin-icons/pin-icons.tsx
+++ b/packages/ui-next/src/components/modules/achievements/pin-icons/pin-icons.tsx
@@ -1,5 +1,5 @@
 import { cva, VariantProps } from "class-variance-authority";
-import { AchievementPinIcon } from "../pin-icon";
+import { AchievementPinIcon } from "../pin-icon/pin-icon";
 
 const achievementPinsVariants = cva("flex items-center gap-1.5", {
   variants: {
@@ -56,5 +56,3 @@ export const AchievementPinIcons = ({
     </div>
   );
 };
-
-export default AchievementPinIcons;

--- a/packages/ui-next/src/components/modules/achievements/pin/pin.tsx
+++ b/packages/ui-next/src/components/modules/achievements/pin/pin.tsx
@@ -1,4 +1,5 @@
-import { Button, TrackIcon } from "@/index";
+import { Button } from "#components/primitives";
+import { TrackIcon } from "#components/icons";
 import { useCallback, useState } from "react";
 
 export interface AchievementPinProps {
@@ -41,5 +42,3 @@ export function AchievementPin({
     </Button>
   );
 }
-
-export default AchievementPin;

--- a/packages/ui-next/src/components/modules/achievements/player-header/player-header.tsx
+++ b/packages/ui-next/src/components/modules/achievements/player-header/player-header.tsx
@@ -75,5 +75,3 @@ const FollowerDescription = ({ followers }: { followers: string[] }) => {
     </p>
   );
 };
-
-export default AchievementPlayerHeader;

--- a/packages/ui-next/src/components/modules/achievements/player-label/player-label.tsx
+++ b/packages/ui-next/src/components/modules/achievements/player-label/player-label.tsx
@@ -1,6 +1,6 @@
-import { CopyAddress } from "@/components/copy-address";
-import { SpaceInvaderIcon } from "@/components/icons";
-import { UniversalHeaderIcon } from "@/index";
+import { CopyAddress } from "#components/copy-address";
+import { SpaceInvaderIcon } from "#components/icons";
+import { UniversalHeaderIcon } from "../../universals/header-icon";
 
 export interface AchievementPlayerLabelProps {
   username: string;
@@ -27,5 +27,3 @@ export const AchievementPlayerLabel = ({
     </div>
   );
 };
-
-export default AchievementPlayerLabel;

--- a/packages/ui-next/src/components/modules/achievements/points/points.tsx
+++ b/packages/ui-next/src/components/modules/achievements/points/points.tsx
@@ -1,5 +1,7 @@
-import { CalendarIcon, cn, Separator, SparklesIcon } from "@/index";
+import { CalendarIcon, SparklesIcon } from "#components/icons";
+import { Separator } from "#components/primitives";
 import { useMemo } from "react";
+import { cn } from "#utils";
 
 interface AchievementPointsProps {
   points: number;
@@ -58,5 +60,3 @@ function Timestamp({ timestamp }: { timestamp: number }) {
     </div>
   );
 }
-
-export default AchievementPoints;

--- a/packages/ui-next/src/components/modules/achievements/progress/progress.tsx
+++ b/packages/ui-next/src/components/modules/achievements/progress/progress.tsx
@@ -1,5 +1,7 @@
-import { cn, ProgressBar, SparklesIcon, TrophyIcon } from "@/index";
 import { cva, VariantProps } from "class-variance-authority";
+import { SparklesIcon, TrophyIcon } from "#components/icons";
+import { cn } from "#utils";
+import { ProgressBar } from "../../progress-bar/progress-bar";
 
 export interface AchievementProgressProps
   extends VariantProps<typeof achievementProgressVariants> {
@@ -51,5 +53,3 @@ export function AchievementProgress({
     </div>
   );
 }
-
-export default AchievementProgress;

--- a/packages/ui-next/src/components/modules/achievements/share/share.tsx
+++ b/packages/ui-next/src/components/modules/achievements/share/share.tsx
@@ -1,4 +1,5 @@
-import { Button, XIcon } from "@/index";
+import { XIcon } from "#components/icons";
+import { Button } from "#components/primitives";
 import { useCallback, useMemo } from "react";
 
 export interface AchievementShareProps {
@@ -72,5 +73,3 @@ Only ${difficulty}% of players have earned this rare badge.
     </Button>
   );
 }
-
-export default AchievementShare;

--- a/packages/ui-next/src/components/modules/achievements/summary/summary.tsx
+++ b/packages/ui-next/src/components/modules/achievements/summary/summary.tsx
@@ -1,15 +1,14 @@
-import {
-  AchievementContentProps,
-  ArcadeGameHeader,
-  AchievementPinProps,
-  AchievementProgress,
-  Card,
-  CardContent,
-  Metadata,
-  Socials,
-} from "@/index";
 import { cva, VariantProps } from "class-variance-authority";
 import { useMemo } from "react";
+import { Card, CardContent } from "#components/primitives";
+import { AchievementContentProps } from "../content/content";
+import { AchievementPinProps } from "../pin/pin";
+import { AchievementProgress } from "../progress/progress";
+import {
+  ArcadeGameHeader,
+  Metadata,
+  Socials,
+} from "#components/modules/arcade";
 
 export interface AchievementSummaryProps
   extends VariantProps<typeof achievementSummaryVariants> {
@@ -73,5 +72,3 @@ export const AchievementSummary = ({
     </Card>
   );
 };
-
-export default AchievementSummary;

--- a/packages/ui-next/src/components/modules/achievements/tab/tab.stories.tsx
+++ b/packages/ui-next/src/components/modules/achievements/tab/tab.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { Tabs, TabsList } from "#components/primitives";
 import { AchievementTab } from "./tab";
-import AchievementCounter from "../counter/counter";
-import { Tabs, TabsList } from "@/index";
-import AchievementLeaderboardCounter from "../leaderboard-counter/leaderboard-counter";
+import { AchievementCounter } from "../counter/counter";
+import { AchievementLeaderboardCounter } from "../leaderboard-counter/leaderboard-counter";
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
   <Tabs defaultValue="achievements">

--- a/packages/ui-next/src/components/modules/achievements/tab/tab.tsx
+++ b/packages/ui-next/src/components/modules/achievements/tab/tab.tsx
@@ -1,6 +1,7 @@
-import { cn, TabsTrigger } from "@/index";
-import AchievementCounter from "../counter/counter";
-import AchievementLeaderboardCounter from "../leaderboard-counter/leaderboard-counter";
+import { TabsTrigger } from "#components/primitives";
+import { cn } from "#utils";
+import { AchievementCounter } from "../counter/counter";
+import { AchievementLeaderboardCounter } from "../leaderboard-counter/leaderboard-counter";
 import React from "react";
 
 export interface AchievementTabProps {
@@ -39,5 +40,3 @@ export const AchievementTab = ({
     </TabsTrigger>
   );
 };
-
-export default AchievementTab;

--- a/packages/ui-next/src/components/modules/achievements/tabs/tabs.stories.tsx
+++ b/packages/ui-next/src/components/modules/achievements/tabs/tabs.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { TabsContent } from "#components/primitives";
 import { AchievementTabs } from "./tabs";
-import { TabsContent } from "@/index";
 
 const meta: Meta<typeof AchievementTabs> = {
   title: "Modules/Achievements/Tabs",

--- a/packages/ui-next/src/components/modules/achievements/tabs/tabs.tsx
+++ b/packages/ui-next/src/components/modules/achievements/tabs/tabs.tsx
@@ -1,7 +1,7 @@
-import { Tabs, TabsList } from "@/index";
-import AchievementTab from "../tab/tab";
-import AchievementCounter from "../counter/counter";
-import AchievementLeaderboardCounter from "../leaderboard-counter/leaderboard-counter";
+import { Tabs, TabsList } from "#components/primitives";
+import { AchievementTab } from "../tab/tab";
+import { AchievementCounter } from "../counter/counter";
+import { AchievementLeaderboardCounter } from "../leaderboard-counter/leaderboard-counter";
 import { useState } from "react";
 
 export interface AchievementTabsProps
@@ -49,5 +49,3 @@ export const AchievementTabs = ({
     </Tabs>
   );
 };
-
-export default AchievementTabs;

--- a/packages/ui-next/src/components/modules/achievements/task-header/task-header.tsx
+++ b/packages/ui-next/src/components/modules/achievements/task-header/task-header.tsx
@@ -1,4 +1,5 @@
-import { CheckboxCheckedIcon, CheckboxUncheckedIcon, cn } from "@/index";
+import { CheckboxCheckedIcon, CheckboxUncheckedIcon } from "#components/icons";
+import { cn } from "#utils";
 import { useMemo } from "react";
 
 interface AchievementTaskHeaderProps {
@@ -33,5 +34,3 @@ export function AchievementTaskHeader({
     </div>
   );
 }
-
-export default AchievementTaskHeader;

--- a/packages/ui-next/src/components/modules/achievements/task-status/task-status.tsx
+++ b/packages/ui-next/src/components/modules/achievements/task-status/task-status.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon } from "@/index";
+import { CheckIcon } from "#components/icons";
 
 interface AchievementTaskStatusProps {
   count: number;
@@ -22,5 +22,3 @@ export function AchievementTaskStatus({
     </p>
   );
 }
-
-export default AchievementTaskStatus;

--- a/packages/ui-next/src/components/modules/achievements/task/task.tsx
+++ b/packages/ui-next/src/components/modules/achievements/task/task.tsx
@@ -1,8 +1,6 @@
-import {
-  ProgressBar,
-  AchievementTaskHeader,
-  AchievementTaskStatus,
-} from "@/index";
+import { ProgressBar } from "#components/modules/progress-bar";
+import { AchievementTaskHeader } from "../task-header";
+import { AchievementTaskStatus } from "../task-status";
 
 export interface AchievementTaskProps {
   count: number;
@@ -31,5 +29,3 @@ export function AchievementTask({
     </div>
   );
 }
-
-export default AchievementTask;

--- a/packages/ui-next/src/components/modules/amount/amount.tsx
+++ b/packages/ui-next/src/components/modules/amount/amount.tsx
@@ -1,4 +1,4 @@
-import { Header, Error, Input } from "@/components";
+import { Header, Error, Input } from "#components";
 import { Max } from "./max";
 import { Conversion } from "./conversion";
 import { Balance } from "./balance";

--- a/packages/ui-next/src/components/modules/arcade/discovery-event/discovery-event.tsx
+++ b/packages/ui-next/src/components/modules/arcade/discovery-event/discovery-event.tsx
@@ -1,7 +1,8 @@
-import { CardTitle, cn, SpaceInvaderIcon } from "@/index";
+import { SpaceInvaderIcon } from "#components/icons";
+import { CardTitle } from "#components/primitives";
+import { cn } from "#utils";
 import { cva, VariantProps } from "class-variance-authority";
 import { useMemo, HTMLAttributes, useState, useEffect } from "react";
-
 export interface ArcadeDiscoveryEventProps
   extends HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof arcadeDiscoveryEventVariants> {

--- a/packages/ui-next/src/components/modules/arcade/discovery-group/discovery-group.tsx
+++ b/packages/ui-next/src/components/modules/arcade/discovery-group/discovery-group.tsx
@@ -1,10 +1,12 @@
 import {
-  ArcadeDiscoveryEvent,
-  ArcadeDiscoveryEventProps,
   ArcadeGameHeader,
   ArcadeGameHeaderProps,
-  cn,
-} from "@/index";
+} from "#components/modules/arcade/game-header";
+import {
+  ArcadeDiscoveryEvent,
+  ArcadeDiscoveryEventProps,
+} from "#components/modules/arcade/discovery-event";
+import { cn } from "#utils";
 import { cva, VariantProps } from "class-variance-authority";
 import { HTMLAttributes } from "react";
 

--- a/packages/ui-next/src/components/modules/arcade/game-header/game-header.tsx
+++ b/packages/ui-next/src/components/modules/arcade/game-header/game-header.tsx
@@ -1,18 +1,20 @@
+import { cva, VariantProps } from "class-variance-authority";
+import { useMemo } from "react";
 import {
-  AchievementContentProps,
-  AchievementPinProps,
-  CardTitle,
-  cn,
   DiscordIcon,
   GitHubIcon,
   GlobeIcon,
   TelegramIcon,
-  useMediaQuery,
   XIcon,
-} from "@/index";
-import { cva, VariantProps } from "class-variance-authority";
-import { useMemo } from "react";
-import { AchievementPinIcons } from "@/components/modules/achievements/pin-icons";
+} from "#components/icons";
+import { CardTitle } from "#components/primitives";
+import { cn } from "#utils";
+import {
+  AchievementContentProps,
+  AchievementPinProps,
+} from "#components/modules/achievements";
+import { AchievementPinIcons } from "#components/modules/achievements/pin-icons";
+import { useMediaQuery } from "#hooks/ui";
 import { ArcadeGameIcon } from "../game-icon";
 
 export interface Metadata {
@@ -280,5 +282,3 @@ const AchievementSocial = ({
     </a>
   );
 };
-
-export default ArcadeGameHeader;

--- a/packages/ui-next/src/components/modules/arcade/game-icon/game-icon.tsx
+++ b/packages/ui-next/src/components/modules/arcade/game-icon/game-icon.tsx
@@ -1,4 +1,5 @@
-import { cn, DojoIcon } from "@/index";
+import { DojoIcon } from "#components/icons";
+import { cn } from "#utils";
 import { cva, VariantProps } from "class-variance-authority";
 
 const arcadeGameIconVariants = cva(

--- a/packages/ui-next/src/components/modules/arcade/game-select/game-select.tsx
+++ b/packages/ui-next/src/components/modules/arcade/game-select/game-select.tsx
@@ -1,4 +1,6 @@
-import { CardTitle, cn, SparklesIcon } from "@/index";
+import { SparklesIcon } from "#components/icons";
+import { CardTitle } from "#components/primitives";
+import { cn } from "#utils";
 import { cva, VariantProps } from "class-variance-authority";
 import { useMemo, HTMLAttributes, useState } from "react";
 import { ArcadeGameIcon } from "../game-icon";

--- a/packages/ui-next/src/components/modules/arcade/header/header.stories.tsx
+++ b/packages/ui-next/src/components/modules/arcade/header/header.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { ArcadeHeader } from "./header";
-import { BellIcon, Button, DotsIcon, SpaceInvaderIcon } from "@/index";
+import { BellIcon, DotsIcon, SpaceInvaderIcon } from "#components/icons";
+import { Button } from "#components/primitives";
 import { fn } from "@storybook/test";
 
 const meta: Meta<typeof ArcadeHeader> = {

--- a/packages/ui-next/src/components/modules/arcade/header/header.tsx
+++ b/packages/ui-next/src/components/modules/arcade/header/header.tsx
@@ -1,4 +1,4 @@
-import { ControllerIcon } from "@/index";
+import { ControllerIcon } from "#components/icons";
 import { useMemo } from "react";
 
 export interface ArcadeHeaderProps extends React.PropsWithChildren {

--- a/packages/ui-next/src/components/modules/arcade/tab/tab.stories.tsx
+++ b/packages/ui-next/src/components/modules/arcade/tab/tab.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { ArcadeTab } from "./tab";
-import { SparklesIcon } from "@/components/icons";
-import { Tabs, TabsList } from "@/index";
+import { SparklesIcon } from "#components/icons";
+import { Tabs, TabsList } from "#components/primitives";
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
   <Tabs className="p-0" defaultValue="assets">

--- a/packages/ui-next/src/components/modules/arcade/tab/tab.tsx
+++ b/packages/ui-next/src/components/modules/arcade/tab/tab.tsx
@@ -1,4 +1,5 @@
-import { cn, TabsTrigger } from "@/index";
+import { TabsTrigger } from "#components/primitives";
+import { cn } from "#utils";
 import { cva, VariantProps } from "class-variance-authority";
 
 const arcadeTabVariants = cva(

--- a/packages/ui-next/src/components/modules/arcade/tabs/tabs.tsx
+++ b/packages/ui-next/src/components/modules/arcade/tabs/tabs.tsx
@@ -3,10 +3,9 @@ import {
   ClockIcon,
   PulseIcon,
   SwordsIcon,
-  Tabs,
-  TabsList,
   TrophyIcon,
-} from "@/index";
+} from "#components/icons";
+import { Tabs, TabsList } from "#components/primitives";
 import { useState } from "react";
 import { ArcadeTab } from "../tab";
 

--- a/packages/ui-next/src/components/modules/create-account/create.tsx
+++ b/packages/ui-next/src/components/modules/create-account/create.tsx
@@ -1,6 +1,6 @@
-import { cn } from "@/utils";
+import { Input } from "#components/primitives";
+import { cn } from "#utils";
 import { Status, ValidationState } from "./status";
-import { Input } from "@/index";
 
 type CreateAccountProps = {
   usernameField: {
@@ -59,5 +59,3 @@ export function CreateAccount({
     </div>
   );
 }
-
-export default CreateAccount;

--- a/packages/ui-next/src/components/modules/progress-bar/progress-bar.tsx
+++ b/packages/ui-next/src/components/modules/progress-bar/progress-bar.tsx
@@ -1,5 +1,5 @@
-import { Progress } from "@/index";
-import { cn } from "@/utils";
+import { Progress } from "#components/primitives";
+import { cn } from "#utils";
 import { useMemo } from "react";
 
 interface ProgressBarProps {

--- a/packages/ui-next/src/components/modules/recipient/preview.tsx
+++ b/packages/ui-next/src/components/modules/recipient/preview.tsx
@@ -5,7 +5,7 @@ import {
   OpenZeppelinIcon,
   WalletIcon,
   WalletType,
-} from "@/components";
+} from "#components";
 import { formatAddress } from "@cartridge/utils";
 import { useCallback } from "react";
 

--- a/packages/ui-next/src/components/modules/recipient/recipient.stories.tsx
+++ b/packages/ui-next/src/components/modules/recipient/recipient.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { WalletType } from "@/components";
+import { WalletType } from "#components";
 import { fn } from "@storybook/test";
 import { Recipient } from "./recipient";
 

--- a/packages/ui-next/src/components/modules/recipient/recipient.tsx
+++ b/packages/ui-next/src/components/modules/recipient/recipient.tsx
@@ -1,4 +1,4 @@
-import { Header, Textarea, WalletType } from "@/components";
+import { Header, Textarea, WalletType } from "#components";
 import { Selection } from "./selection";
 import { Preview } from "./preview";
 import { formatAddress } from "@cartridge/utils";

--- a/packages/ui-next/src/components/modules/recipient/selection.tsx
+++ b/packages/ui-next/src/components/modules/recipient/selection.tsx
@@ -5,8 +5,8 @@ import {
   OpenZeppelinIcon,
   WalletIcon,
   WalletType,
-} from "@/components";
-import { cn } from "@/utils";
+} from "#components";
+import { cn } from "#utils";
 import { useCallback } from "react";
 
 type SelectionProps = {

--- a/packages/ui-next/src/components/modules/universals/header-icon/header-icon.stories.tsx
+++ b/packages/ui-next/src/components/modules/universals/header-icon/header-icon.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { UniversalHeaderIcon } from "./header-icon";
-import { DepositIcon, EthereumColorIcon } from "@/components/icons";
+import { DepositIcon, EthereumColorIcon } from "#components/icons";
 
 const meta: Meta<typeof UniversalHeaderIcon> = {
   title: "Modules/Universals/Header Icon",

--- a/packages/ui-next/src/components/modules/universals/header-icon/header-icon.tsx
+++ b/packages/ui-next/src/components/modules/universals/header-icon/header-icon.tsx
@@ -1,4 +1,5 @@
-import { cn, SpaceInvaderIcon } from "@/index";
+import { SpaceInvaderIcon } from "#components/icons";
+import { cn } from "#utils";
 import { cva, VariantProps } from "class-variance-authority";
 
 const headerIconVariants = cva("flex items-center justify-center rounded", {
@@ -45,5 +46,3 @@ export const UniversalHeaderIcon = ({
     </div>
   );
 };
-
-export default UniversalHeaderIcon;

--- a/packages/ui-next/src/components/modules/universals/header-label/header-label.stories.tsx
+++ b/packages/ui-next/src/components/modules/universals/header-label/header-label.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { UniversalHeaderLabel } from "./header-label";
-import { DepositIcon } from "@/components/icons";
+import { DepositIcon } from "#components/icons";
 
 const meta: Meta<typeof UniversalHeaderLabel> = {
   title: "Modules/Universals/Header Label",

--- a/packages/ui-next/src/components/modules/universals/header-label/header-label.tsx
+++ b/packages/ui-next/src/components/modules/universals/header-label/header-label.tsx
@@ -1,4 +1,5 @@
-import { cn, UniversalHeaderIcon } from "@/index";
+import { cn } from "#utils";
+import { UniversalHeaderIcon } from "../header-icon";
 import { cva, VariantProps } from "class-variance-authority";
 
 const headerLabelVariants = cva("flex gap-x-4 items-center", {
@@ -38,5 +39,3 @@ export const UniversalHeaderLabel = ({
     </div>
   );
 };
-
-export default UniversalHeaderLabel;

--- a/packages/ui-next/src/components/primitives/accordion.tsx
+++ b/packages/ui-next/src/components/primitives/accordion.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
-import { cn } from "@/utils";
+import { cn } from "#utils";
 import { WedgeIcon } from "../icons";
 
 const Accordion = AccordionPrimitive.Root;

--- a/packages/ui-next/src/components/primitives/alert-dialog.tsx
+++ b/packages/ui-next/src/components/primitives/alert-dialog.tsx
@@ -3,8 +3,8 @@
 import * as React from "react";
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 
-import { cn } from "@/utils";
-import { buttonVariants } from "@/components/primitives/button/utils";
+import { cn } from "#utils";
+import { buttonVariants } from "#components/primitives/button/utils";
 
 const AlertDialog = AlertDialogPrimitive.Root;
 

--- a/packages/ui-next/src/components/primitives/alert.tsx
+++ b/packages/ui-next/src/components/primitives/alert.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/utils";
+import { cn } from "#utils";
 
 const alertVariants = cva(
   "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-2.5 [&>svg]:top-3 [&>svg]:text-foreground [&>svg~*]:pl-7",

--- a/packages/ui-next/src/components/primitives/badge.tsx
+++ b/packages/ui-next/src/components/primitives/badge.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/utils";
+import { cn } from "#utils";
 
 const badgeVariants = cva(
   "inline-flex items-center rounded-md px-1 py-0.5 text-xs font-semibold transition-colors focus:outline-none",

--- a/packages/ui-next/src/components/primitives/bottom-tab.tsx
+++ b/packages/ui-next/src/components/primitives/bottom-tab.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
-import { cn } from "@/utils";
+import { cn } from "#utils";
 
 const bottomTabVariants = cva("flex flex-col items-center", {
   variants: {

--- a/packages/ui-next/src/components/primitives/breadcrumb.tsx
+++ b/packages/ui-next/src/components/primitives/breadcrumb.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 
-import { cn } from "@/utils";
+import { cn } from "#utils";
 import { DotsIcon, WedgeIcon } from "../icons";
 
 const Breadcrumb = React.forwardRef<

--- a/packages/ui-next/src/components/primitives/button/index.tsx
+++ b/packages/ui-next/src/components/primitives/button/index.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { type VariantProps } from "class-variance-authority";
-import { cn } from "@/utils";
-import { Spinner } from "@/components/spinner";
+import { cn } from "#utils";
+import { Spinner } from "#components/spinner";
 import { buttonVariants } from "./utils";
-import { ExternalIcon } from "@/components/icons";
+import { ExternalIcon } from "#components/icons";
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,

--- a/packages/ui-next/src/components/primitives/card.tsx
+++ b/packages/ui-next/src/components/primitives/card.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { cn } from "@/utils";
+import { cn } from "#utils";
 
 export const Card = React.forwardRef<
   HTMLDivElement,

--- a/packages/ui-next/src/components/primitives/checkbox.tsx
+++ b/packages/ui-next/src/components/primitives/checkbox.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 
-import { cn } from "@/utils";
+import { cn } from "#utils";
 import { CheckboxIcon } from "../icons";
 import { iconVariants, size } from "../icons/utils";
 

--- a/packages/ui-next/src/components/primitives/command.tsx
+++ b/packages/ui-next/src/components/primitives/command.tsx
@@ -2,11 +2,11 @@
 
 import * as React from "react";
 import { type DialogProps } from "@radix-ui/react-dialog";
-import { MagnifyingGlassIcon } from "@/components/icons";
+import { MagnifyingGlassIcon } from "#components/icons";
 import { Command as CommandPrimitive } from "cmdk";
 
-import { cn } from "@/utils";
-import { Dialog, DialogContent } from "@/components/primitives/dialog";
+import { cn } from "#utils";
+import { Dialog, DialogContent } from "#components/primitives/dialog";
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,

--- a/packages/ui-next/src/components/primitives/dialog.tsx
+++ b/packages/ui-next/src/components/primitives/dialog.tsx
@@ -3,8 +3,8 @@
 import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 
-import { cn } from "@/utils";
-import { TimesIcon } from "@/components/icons";
+import { cn } from "#utils";
+import { TimesIcon } from "#components/icons";
 
 const Dialog = DialogPrimitive.Root;
 

--- a/packages/ui-next/src/components/primitives/drawer.tsx
+++ b/packages/ui-next/src/components/primitives/drawer.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { Drawer as DrawerPrimitive } from "vaul";
 
-import { cn } from "@/utils";
+import { cn } from "#utils";
 
 const Drawer = ({
   shouldScaleBackground = true,

--- a/packages/ui-next/src/components/primitives/dropdown-menu.tsx
+++ b/packages/ui-next/src/components/primitives/dropdown-menu.tsx
@@ -2,8 +2,8 @@
 
 import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import { CheckIcon, CircleIcon, WedgeIcon } from "@/components/icons";
-import { cn } from "@/utils";
+import { CheckIcon, CircleIcon, WedgeIcon } from "#components/icons";
+import { cn } from "#utils";
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
 

--- a/packages/ui-next/src/components/primitives/hover-card.tsx
+++ b/packages/ui-next/src/components/primitives/hover-card.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
 
-import { cn } from "@/utils";
+import { cn } from "#utils";
 
 const HoverCard = HoverCardPrimitive.Root;
 

--- a/packages/ui-next/src/components/primitives/input.tsx
+++ b/packages/ui-next/src/components/primitives/input.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
-import { AlertIcon } from "@/components/icons";
-import { cn } from "@/utils";
-import { Clear } from "./clear";
+import { Clear } from "#components/primitives/clear";
+import { AlertIcon } from "#components/icons";
+import { cn } from "#utils";
 import { cva, VariantProps } from "class-variance-authority";
 
 interface InputProps

--- a/packages/ui-next/src/components/primitives/label.tsx
+++ b/packages/ui-next/src/components/primitives/label.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import * as LabelPrimitive from "@radix-ui/react-label";
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/utils";
+import { cn } from "#utils";
 
 const labelVariants = cva(
   "text-xs text-foreground-400 font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 uppercase",

--- a/packages/ui-next/src/components/primitives/menubar.tsx
+++ b/packages/ui-next/src/components/primitives/menubar.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import * as React from "react";
-import { CheckIcon, CircleIcon, WedgeIcon } from "@/components/icons";
+import { CheckIcon, CircleIcon, WedgeIcon } from "#components/icons";
 import * as MenubarPrimitive from "@radix-ui/react-menubar";
 
-import { cn } from "@/utils";
+import { cn } from "#utils";
 
 const MenubarMenu: typeof MenubarPrimitive.Menu = MenubarPrimitive.Menu;
 

--- a/packages/ui-next/src/components/primitives/popover.tsx
+++ b/packages/ui-next/src/components/primitives/popover.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 
-import { cn } from "@/utils";
+import { cn } from "#utils";
 
 const Popover = PopoverPrimitive.Root;
 

--- a/packages/ui-next/src/components/primitives/progress.tsx
+++ b/packages/ui-next/src/components/primitives/progress.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import * as ProgressPrimitive from "@radix-ui/react-progress";
 
-import { cn } from "@/utils";
+import { cn } from "#utils";
 
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,

--- a/packages/ui-next/src/components/primitives/radio-group.tsx
+++ b/packages/ui-next/src/components/primitives/radio-group.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import * as React from "react";
-import { CheckIcon } from "@/components/icons";
+import { CheckIcon } from "#components/icons";
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 
-import { cn } from "@/utils";
+import { cn } from "#utils";
 
 const RadioGroup = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Root>,

--- a/packages/ui-next/src/components/primitives/select.tsx
+++ b/packages/ui-next/src/components/primitives/select.tsx
@@ -2,8 +2,8 @@
 
 import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
-import { CaratIcon, CircleCheckIcon, WedgeIcon } from "@/components/icons";
-import { cn } from "@/utils";
+import { CaratIcon, CircleCheckIcon, WedgeIcon } from "#components/icons";
+import { cn } from "#utils";
 
 const Select = SelectPrimitive.Root;
 

--- a/packages/ui-next/src/components/primitives/separator.tsx
+++ b/packages/ui-next/src/components/primitives/separator.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import * as SeparatorPrimitive from "@radix-ui/react-separator";
 
-import { cn } from "@/utils";
+import { cn } from "#utils";
 
 const Separator = React.forwardRef<
   React.ElementRef<typeof SeparatorPrimitive.Root>,

--- a/packages/ui-next/src/components/primitives/sheet.tsx
+++ b/packages/ui-next/src/components/primitives/sheet.tsx
@@ -3,8 +3,8 @@
 import * as React from "react";
 import * as SheetPrimitive from "@radix-ui/react-dialog";
 import { cva, type VariantProps } from "class-variance-authority";
-import { TimesIcon } from "@/components/icons";
-import { cn } from "@/utils";
+import { TimesIcon } from "#components/icons";
+import { cn } from "#utils";
 
 const Sheet = SheetPrimitive.Root;
 

--- a/packages/ui-next/src/components/primitives/skeleton.tsx
+++ b/packages/ui-next/src/components/primitives/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/utils";
+import { cn } from "#utils";
 
 function Skeleton({
   className,

--- a/packages/ui-next/src/components/primitives/switch.tsx
+++ b/packages/ui-next/src/components/primitives/switch.tsx
@@ -3,7 +3,7 @@
 import * as SwitchPrimitives from "@radix-ui/react-switch";
 import * as React from "react";
 
-import { cn } from "@/utils";
+import { cn } from "#utils";
 
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,

--- a/packages/ui-next/src/components/primitives/table.tsx
+++ b/packages/ui-next/src/components/primitives/table.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { cn } from "@/utils";
+import { cn } from "#utils";
 
 const Table = React.forwardRef<
   HTMLTableElement,

--- a/packages/ui-next/src/components/primitives/tabs.tsx
+++ b/packages/ui-next/src/components/primitives/tabs.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 
-import { cn } from "@/utils";
+import { cn } from "#utils";
 
 const Tabs = TabsPrimitive.Root;
 

--- a/packages/ui-next/src/components/primitives/textarea.tsx
+++ b/packages/ui-next/src/components/primitives/textarea.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 
-import { cn } from "@/utils";
-import { Clear } from "./clear";
+import { cn } from "#utils";
 import { cva, VariantProps } from "class-variance-authority";
-import { ErrorMessage } from "@/index";
+import { ErrorMessage } from "#components/primitives/input";
+import { Clear } from "#components/primitives/clear";
 
 export const textareaVariants = cva(
   "flex w-full resize-none overflow-hidden rounded-md border px-4 font-mono ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 [&::-webkit-inner-spin-button]:appearance-none",

--- a/packages/ui-next/src/components/primitives/toast.tsx
+++ b/packages/ui-next/src/components/primitives/toast.tsx
@@ -3,8 +3,8 @@
 import * as React from "react";
 import * as ToastPrimitives from "@radix-ui/react-toast";
 import { cva, type VariantProps } from "class-variance-authority";
-import { TimesIcon } from "@/components/icons";
-import { cn } from "@/utils";
+import { TimesIcon } from "#components/icons";
+import { cn } from "#utils";
 
 const ToastProvider = ToastPrimitives.Provider;
 

--- a/packages/ui-next/src/components/primitives/toaster.tsx
+++ b/packages/ui-next/src/components/primitives/toaster.tsx
@@ -7,8 +7,8 @@ import {
   ToastProvider,
   ToastTitle,
   ToastViewport,
-} from "@/components/primitives/toast";
-import { useToast } from "@/components/primitives/use-toast";
+} from "#components/primitives/toast";
+import { useToast } from "#components/primitives/use-toast";
 
 export function Toaster() {
   const { toasts } = useToast();

--- a/packages/ui-next/src/components/primitives/toggle-group.tsx
+++ b/packages/ui-next/src/components/primitives/toggle-group.tsx
@@ -4,8 +4,8 @@ import * as React from "react";
 import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
 import { VariantProps } from "class-variance-authority";
 
-import { cn } from "@/utils";
-import { toggleVariants } from "@/components/primitives/toggle/utils";
+import { cn } from "#utils";
+import { toggleVariants } from "#components/primitives/toggle/utils";
 
 const ToggleGroupContext = React.createContext<
   VariantProps<typeof toggleVariants>

--- a/packages/ui-next/src/components/primitives/toggle/index.tsx
+++ b/packages/ui-next/src/components/primitives/toggle/index.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import * as TogglePrimitive from "@radix-ui/react-toggle";
 import { type VariantProps } from "class-variance-authority";
-import { cn } from "@/utils";
+import { cn } from "#utils";
 import { toggleVariants } from "./utils";
 
 export const Toggle = React.forwardRef<

--- a/packages/ui-next/src/components/primitives/tooltip.tsx
+++ b/packages/ui-next/src/components/primitives/tooltip.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
-import { cn } from "@/utils";
+import { cn } from "#utils";
 import { createPortal } from "react-dom";
 
 const TooltipProvider = ({

--- a/packages/ui-next/src/components/primitives/use-toast.ts
+++ b/packages/ui-next/src/components/primitives/use-toast.ts
@@ -6,7 +6,7 @@ import * as React from "react";
 import type {
   ToastActionElement,
   ToastProps,
-} from "@/components/primitives/toast";
+} from "#components/primitives/toast";
 
 const TOAST_LIMIT = 1;
 const TOAST_REMOVE_DELAY = 1000000;

--- a/packages/ui-next/src/components/spinner.tsx
+++ b/packages/ui-next/src/components/spinner.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/utils";
+import { cn } from "#utils";
 import { IconProps, SpinnerIcon } from "./icons";
 
 export function Spinner({ className, ...props }: IconProps) {

--- a/packages/ui-next/src/components/typography/mono.stories.tsx
+++ b/packages/ui-next/src/components/typography/mono.stories.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/utils";
+import { cn } from "#utils";
 import type { Meta, StoryObj } from "@storybook/react";
 
 const P = ({ label, className }: { label: string; className: string }) => {

--- a/packages/ui-next/src/components/typography/sans.stories.tsx
+++ b/packages/ui-next/src/components/typography/sans.stories.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/utils";
+import { cn } from "#utils";
 import type { Meta, StoryObj } from "@storybook/react";
 
 const P = ({ label, className }: { label: string; className: string }) => {

--- a/packages/ui-next/src/hooks/ui.ts
+++ b/packages/ui-next/src/hooks/ui.ts
@@ -1,5 +1,5 @@
-import { UIContext } from "@/context";
-import { useCallback, useContext, useState } from "react";
+import { UIContext } from "#context";
+import { useCallback, useContext, useEffect, useState } from "react";
 
 export function useDisclosure() {
   const [isOpen, setIsOpen] = useState(false);
@@ -26,4 +26,22 @@ export function useDisclosure() {
 
 export function useUI() {
   return useContext(UIContext);
+}
+
+export function useMediaQuery(query: string) {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    setMatches(media.matches);
+
+    const listener = (e: MediaQueryListEvent) => {
+      setMatches(e.matches);
+    };
+
+    media.addEventListener("change", listener);
+    return () => media.removeEventListener("change", listener);
+  }, [query]);
+
+  return matches;
 }

--- a/packages/ui-next/src/stories/accordion.stories.tsx
+++ b/packages/ui-next/src/stories/accordion.stories.tsx
@@ -3,7 +3,7 @@ import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
-} from "@/components/primitives/accordion";
+} from "#components/primitives/accordion";
 import { Meta, StoryObj } from "@storybook/react";
 import { CircleIcon, InfoIcon } from "../";
 

--- a/packages/ui-next/src/stories/alert.stories.tsx
+++ b/packages/ui-next/src/stories/alert.stories.tsx
@@ -1,9 +1,9 @@
-import { AlertIcon, TerminalIcon } from "@/components/icons";
+import { AlertIcon, TerminalIcon } from "#components/icons";
 import {
   Alert as UIAlert,
   AlertDescription,
   AlertTitle,
-} from "@/components/primitives/alert";
+} from "#components/primitives/alert";
 
 import { Meta, StoryObj } from "@storybook/react";
 

--- a/packages/ui-next/src/stories/badge.stories.tsx
+++ b/packages/ui-next/src/stories/badge.stories.tsx
@@ -1,4 +1,4 @@
-import { Badge } from "@/components/primitives/badge";
+import { Badge } from "#components/primitives/badge";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Badge> = {

--- a/packages/ui-next/src/stories/bottom-tab.stories.tsx
+++ b/packages/ui-next/src/stories/bottom-tab.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { BottomTab } from "@/components/primitives/index";
-import { ChestIcon } from "@/components/icons";
+import { BottomTab } from "#components/primitives/index";
+import { ChestIcon } from "#components/icons";
 
 const meta: Meta<typeof BottomTab> = {
   title: "Primitives/BottomTab",

--- a/packages/ui-next/src/stories/breadcrumb.stories.tsx
+++ b/packages/ui-next/src/stories/breadcrumb.stories.tsx
@@ -6,8 +6,8 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
   BreadcrumbEllipsis,
-} from "@/components/primitives/breadcrumb";
-import { SlashIcon } from "@/components/icons";
+} from "#components/primitives/breadcrumb";
+import { SlashIcon } from "#components/icons";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Breadcrumb> = {

--- a/packages/ui-next/src/stories/button.stories.tsx
+++ b/packages/ui-next/src/stories/button.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { Button } from "@/components/primitives/button";
-import { ArrowToLineIcon, CoinsIcon, GiftIcon } from "@/components";
+import { Button } from "#components/primitives/button";
+import { ArrowToLineIcon, CoinsIcon, GiftIcon } from "#components";
 
 const meta: Meta<typeof Button> = {
   title: "Primitives/Button",

--- a/packages/ui-next/src/stories/card.stories.tsx
+++ b/packages/ui-next/src/stories/card.stories.tsx
@@ -8,8 +8,8 @@ import {
   CardIcon,
   CardListContent,
   CardListItem,
-} from "@/components/primitives/card";
-import { EthereumIcon } from "@/components/icons";
+} from "#components/primitives/card";
+import { EthereumIcon } from "#components/icons";
 import { Meta, StoryObj } from "@storybook/react";
 import { useEffect } from "react";
 

--- a/packages/ui-next/src/stories/checkbox.stories.tsx
+++ b/packages/ui-next/src/stories/checkbox.stories.tsx
@@ -1,4 +1,4 @@
-import { Checkbox as UICheckbox } from "@/components/primitives/checkbox";
+import { Checkbox as UICheckbox } from "#components/primitives/checkbox";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Checkbox> = {

--- a/packages/ui-next/src/stories/command.stories.tsx
+++ b/packages/ui-next/src/stories/command.stories.tsx
@@ -6,7 +6,7 @@ import {
   CommandItem,
   CommandList,
   CommandSeparator,
-} from "@/components/primitives/command";
+} from "#components/primitives/command";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Command> = {

--- a/packages/ui-next/src/stories/dialog.stories.tsx
+++ b/packages/ui-next/src/stories/dialog.stories.tsx
@@ -9,7 +9,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   AlertDialogTrigger,
-} from "@/components/primitives/alert-dialog";
+} from "#components/primitives/alert-dialog";
 import {
   Dialog as UIDialog,
   DialogContent,
@@ -17,7 +17,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from "@/components/primitives/dialog";
+} from "#components/primitives/dialog";
 
 const meta: Meta<typeof Dialog> = {
   title: "Primitives/Dialog",

--- a/packages/ui-next/src/stories/drawer.stories.tsx
+++ b/packages/ui-next/src/stories/drawer.stories.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/primitives/button";
+import { Button } from "#components/primitives/button";
 import {
   Drawer as UIDrawer,
   DrawerClose,
@@ -8,7 +8,7 @@ import {
   DrawerHeader,
   DrawerTitle,
   DrawerTrigger,
-} from "@/components/primitives/drawer";
+} from "#components/primitives/drawer";
 
 import { Meta, StoryObj } from "@storybook/react";
 

--- a/packages/ui-next/src/stories/dropdown-menu.stories.tsx
+++ b/packages/ui-next/src/stories/dropdown-menu.stories.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuSub,
   DropdownMenuRadioItem,
   DropdownMenuRadioGroup,
-} from "@/components/primitives/dropdown-menu";
+} from "#components/primitives/dropdown-menu";
 
 const meta: Meta<typeof DropdownMenu> = {
   title: "Primitives/Dropdown Menu",

--- a/packages/ui-next/src/stories/hover-card.stories.tsx
+++ b/packages/ui-next/src/stories/hover-card.stories.tsx
@@ -2,7 +2,7 @@ import {
   HoverCard as UIHoverCard,
   HoverCardContent,
   HoverCardTrigger,
-} from "@/components/primitives/hover-card";
+} from "#components/primitives/hover-card";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof HoverCard> = {

--- a/packages/ui-next/src/stories/icons.stories.tsx
+++ b/packages/ui-next/src/stories/icons.stories.tsx
@@ -4,14 +4,14 @@ import {
   directionalIcons,
   stateIcons,
   utilityIcons,
-} from "@/components/icons";
+} from "#components/icons";
 import {
   DirectionalIconProps,
   IconProps,
   StateIconProps,
-} from "@/components/icons/types";
-import { size } from "@/components/icons/utils";
-import { cn } from "@/utils";
+} from "#components/icons/types";
+import { size } from "#components/icons/utils";
+import { cn } from "#utils";
 import { Meta, StoryObj } from "@storybook/react";
 import { ComponentType } from "react";
 

--- a/packages/ui-next/src/stories/input.stories.tsx
+++ b/packages/ui-next/src/stories/input.stories.tsx
@@ -1,4 +1,4 @@
-import { Input } from "@/components/primitives/input";
+import { Input } from "#components/primitives/input";
 import { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
 

--- a/packages/ui-next/src/stories/label.stories.tsx
+++ b/packages/ui-next/src/stories/label.stories.tsx
@@ -1,5 +1,5 @@
-import { Input as UIInput } from "@/components/primitives/input";
-import { Label as UILabel } from "@/components/primitives/label";
+import { Input as UIInput } from "#components/primitives/input";
+import { Label as UILabel } from "#components/primitives/label";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Label> = {

--- a/packages/ui-next/src/stories/menubar.stories.tsx
+++ b/packages/ui-next/src/stories/menubar.stories.tsx
@@ -6,7 +6,7 @@ import {
   MenubarSeparator,
   MenubarShortcut,
   MenubarTrigger,
-} from "@/components/primitives/menubar";
+} from "#components/primitives/menubar";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Menubar> = {

--- a/packages/ui-next/src/stories/popover.stories.tsx
+++ b/packages/ui-next/src/stories/popover.stories.tsx
@@ -2,7 +2,7 @@ import {
   Popover as UIPopover,
   PopoverContent,
   PopoverTrigger,
-} from "@/components/primitives/popover";
+} from "#components/primitives/popover";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Popover> = {

--- a/packages/ui-next/src/stories/progress.stories.tsx
+++ b/packages/ui-next/src/stories/progress.stories.tsx
@@ -1,4 +1,4 @@
-import { Progress as UIProgress } from "@/components/primitives/progress";
+import { Progress as UIProgress } from "#components/primitives/progress";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Progress> = {

--- a/packages/ui-next/src/stories/radio-group.stories.tsx
+++ b/packages/ui-next/src/stories/radio-group.stories.tsx
@@ -1,8 +1,8 @@
-import { Label } from "@/components/primitives/label";
+import { Label } from "#components/primitives/label";
 import {
   RadioGroup as UIRadioGroup,
   RadioGroupItem,
-} from "@/components/primitives/radio-group";
+} from "#components/primitives/radio-group";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof RadioGroup> = {

--- a/packages/ui-next/src/stories/select.stories.tsx
+++ b/packages/ui-next/src/stories/select.stories.tsx
@@ -4,7 +4,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/primitives/select";
+} from "#components/primitives/select";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Select> = {

--- a/packages/ui-next/src/stories/separator.stories.tsx
+++ b/packages/ui-next/src/stories/separator.stories.tsx
@@ -1,4 +1,4 @@
-import { Separator as UISeparator } from "@/components/primitives/separator";
+import { Separator as UISeparator } from "#components/primitives/separator";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Separator> = {

--- a/packages/ui-next/src/stories/sheet.stories.tsx
+++ b/packages/ui-next/src/stories/sheet.stories.tsx
@@ -5,7 +5,7 @@ import {
   SheetHeader,
   SheetTitle,
   SheetTrigger,
-} from "@/components/primitives/sheet";
+} from "#components/primitives/sheet";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Sheet> = {

--- a/packages/ui-next/src/stories/skeleton.stories.tsx
+++ b/packages/ui-next/src/stories/skeleton.stories.tsx
@@ -1,4 +1,4 @@
-import { Skeleton as UISkeleton } from "@/components/primitives/skeleton";
+import { Skeleton as UISkeleton } from "#components/primitives/skeleton";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Skeleton> = {

--- a/packages/ui-next/src/stories/sonner.stories.tsx
+++ b/packages/ui-next/src/stories/sonner.stories.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/primitives/button";
+import { Button } from "#components/primitives/button";
 import { Meta, StoryObj } from "@storybook/react";
 import { toast } from "sonner";
 

--- a/packages/ui-next/src/stories/switch.stories.tsx
+++ b/packages/ui-next/src/stories/switch.stories.tsx
@@ -1,4 +1,4 @@
-import { Switch as UISwitch } from "@/components/primitives/switch";
+import { Switch as UISwitch } from "#components/primitives/switch";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Switch> = {

--- a/packages/ui-next/src/stories/table.stories.tsx
+++ b/packages/ui-next/src/stories/table.stories.tsx
@@ -7,7 +7,7 @@ import {
   TableHeader,
   TableRow,
   TableFooter,
-} from "@/components/primitives/table";
+} from "#components/primitives/table";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Table> = {

--- a/packages/ui-next/src/stories/tabs.stories.tsx
+++ b/packages/ui-next/src/stories/tabs.stories.tsx
@@ -3,7 +3,7 @@ import {
   TabsContent,
   TabsList,
   TabsTrigger,
-} from "@/components/primitives/tabs";
+} from "#components/primitives/tabs";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Tabs> = {

--- a/packages/ui-next/src/stories/textarea.stories.tsx
+++ b/packages/ui-next/src/stories/textarea.stories.tsx
@@ -1,4 +1,4 @@
-import { Textarea } from "@/components/primitives/textarea";
+import { Textarea } from "#components/primitives/textarea";
 import { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
 

--- a/packages/ui-next/src/stories/toast.stories.tsx
+++ b/packages/ui-next/src/stories/toast.stories.tsx
@@ -1,5 +1,5 @@
-import { Button } from "@/components/primitives/button";
-import { useToast } from "@/components/primitives/use-toast";
+import { Button } from "#components/primitives/button";
+import { useToast } from "#components/primitives/use-toast";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Toast> = {

--- a/packages/ui-next/src/stories/toggle-group.stories.tsx
+++ b/packages/ui-next/src/stories/toggle-group.stories.tsx
@@ -1,7 +1,7 @@
 import {
   ToggleGroup as UIToggleGroup,
   ToggleGroupItem,
-} from "@/components/primitives/toggle-group";
+} from "#components/primitives/toggle-group";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof ToggleGroup> = {

--- a/packages/ui-next/src/stories/toggle.stories.tsx
+++ b/packages/ui-next/src/stories/toggle.stories.tsx
@@ -1,5 +1,5 @@
-import { MoonIcon } from "@/components/icons";
-import { Toggle as UIToggle } from "@/components/primitives/toggle";
+import { MoonIcon } from "#components/icons";
+import { Toggle as UIToggle } from "#components/primitives/toggle";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Toggle> = {

--- a/packages/ui-next/src/stories/tooltip.stories.tsx
+++ b/packages/ui-next/src/stories/tooltip.stories.tsx
@@ -3,7 +3,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "@/components/primitives/tooltip";
+} from "#components/primitives/tooltip";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Tooltip> = {

--- a/packages/ui-next/tsconfig.json
+++ b/packages/ui-next/tsconfig.json
@@ -5,9 +5,6 @@
     "baseUrl": ".",
     "rootDir": "./src",
     "outDir": "./dist",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
   },
   "include": [
     "src/components/**/*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -966,9 +966,6 @@ importers:
       tailwindcss:
         specifier: 'catalog:'
         version: 3.4.17(ts-node@10.9.2(@swc/core@1.10.14(@swc/helpers@0.5.15))(@types/node@22.13.1)(typescript@5.7.3))
-      tsc-alias:
-        specifier: ^1.8.10
-        version: 1.8.10
       typescript:
         specifier: 'catalog:'
         version: 5.7.3
@@ -4744,10 +4741,6 @@ packages:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
 
-  commander@9.5.0:
-    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
-    engines: {node: ^12.20.0 || >=14}
-
   common-tags@1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
     engines: {node: '>=4.0.0'}
@@ -7004,10 +6997,6 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
-  mylas@2.1.13:
-    resolution: {integrity: sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==}
-    engines: {node: '>=12.0.0'}
-
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -7451,10 +7440,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  plimit-lit@1.6.1:
-    resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
-    engines: {node: '>=12'}
-
   pngjs@3.4.0:
     resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
     engines: {node: '>=4.0.0'}
@@ -7674,10 +7659,6 @@ packages:
 
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
-
-  queue-lit@1.5.2:
-    resolution: {integrity: sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==}
-    engines: {node: '>=12'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -8576,10 +8557,6 @@ packages:
 
   ts-toolbelt@6.15.5:
     resolution: {integrity: sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==}
-
-  tsc-alias@1.8.10:
-    resolution: {integrity: sha512-Ibv4KAWfFkFdKJxnWfVtdOmB0Zi1RJVxcbPGiCDsFpCQSsmpWyuzHG3rQyI5YkobWwxFPEyQfu1hdo4qLG2zPw==}
-    hasBin: true
 
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
@@ -13811,8 +13788,6 @@ snapshots:
 
   commander@4.1.1: {}
 
-  commander@9.5.0: {}
-
   common-tags@1.8.2: {}
 
   commondir@1.0.1: {}
@@ -16719,8 +16694,6 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  mylas@2.1.13: {}
-
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -17205,10 +17178,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  plimit-lit@1.6.1:
-    dependencies:
-      queue-lit: 1.5.2
-
   pngjs@3.4.0: {}
 
   pngjs@6.0.0: {}
@@ -17410,8 +17379,6 @@ snapshots:
   querystring-es3@0.2.1: {}
 
   querystringify@2.2.0: {}
-
-  queue-lit@1.5.2: {}
 
   queue-microtask@1.2.3: {}
 
@@ -18538,15 +18505,6 @@ snapshots:
     optional: true
 
   ts-toolbelt@6.15.5: {}
-
-  tsc-alias@1.8.10:
-    dependencies:
-      chokidar: 3.6.0
-      commander: 9.5.0
-      globby: 11.1.0
-      mylas: 2.1.13
-      normalize-path: 3.0.0
-      plimit-lit: 1.6.1
 
   tsconfig-paths@3.15.0:
     dependencies:


### PR DESCRIPTION
- Migrate to subpath imports from ts alias
- Remove `ts-alias` dependency
- Break up root dir imports
- Remove default exports