### PR TITLE
Fix typos: Correct spelling of "approval" and "represented" in comments

### DIFF
--- a/packages/keychain/src/utils/connection/sign.ts
+++ b/packages/keychain/src/utils/connection/sign.ts
@@ -38,7 +38,7 @@ export function signMessageFactory(setContext: (ctx: ConnectionCtx) => void) {
         }
 
         // If a session call and there is no session available
-        // fallback to manual apporval flow
+        // fallback to manual approval flow
         if (!(await controller.hasAuthorizedPoliciesForMessage(typedData))) {
           setContext({
             type: "sign-message",

--- a/packages/profile/src/hooks/events.ts
+++ b/packages/profile/src/hooks/events.ts
@@ -19,7 +19,7 @@ function getSelectorFromTag(namespace: string, event: string): string {
   ]);
 }
 
-// Poseidon hash of a string representated as a ByteArray
+// Poseidon hash of a string represented as a ByteArray
 function computeByteArrayHash(str: string): string {
   const bytes = byteArray.byteArrayFromString(str);
   return hash.computePoseidonHashOnElements(serializeByteArray(bytes));

--- a/packages/profile/src/models/index.ts
+++ b/packages/profile/src/models/index.ts
@@ -11,7 +11,7 @@ export function getSelectorFromTag(namespace: string, event: string): string {
   ]);
 }
 
-// Poseidon hash of a string representated as a ByteArray
+// Poseidon hash of a string represented as a ByteArray
 export function computeByteArrayHash(str: string): string {
   const bytes = byteArray.byteArrayFromString(str);
   return hash.computePoseidonHashOnElements(serializeByteArray(bytes));


### PR DESCRIPTION
This PR fixes the following typos in comments:
- Corrects "apporval" to "approval" in packages/keychain/src/utils/connection/sign.ts
- Corrects "representated" to "represented" in packages/profile/src/hooks/events.ts and packages/profile/src/models/index.ts

These changes only affect comments and have no functional impact on the code.