### PR TITLE
Revert "Use connection value hook for policy detection (#1695)"

### DIFF
--- a/packages/keychain/src/components/purchase/index.tsx
+++ b/packages/keychain/src/components/purchase/index.tsx
@@ -1,5 +1,5 @@
 import { ErrorAlert } from "@/components/ErrorAlert";
-import { useConnection, useConnectionValue } from "@/hooks/connection";
+import { useConnection } from "@/hooks/connection";
 import { useWallets } from "@/hooks/wallets";
 import {
   Button,
@@ -70,8 +70,7 @@ export function Purchase({
   starterpackDetails,
   initState = PurchaseState.SELECTION,
 }: PurchaseCreditsProps) {
-  const { controller, closeModal } = useConnection();
-  const { policies } = useConnectionValue();
+  const { controller, closeModal, policies } = useConnection();
   const {
     isLoading: isLoadingWallets,
     error: walletError,
@@ -97,7 +96,6 @@ export function Purchase({
     if (!controller || !policies) {
       return;
     }
-
     controller.isRequestedSession(policies).then((isValid) => {
       setHasValidSession(isValid);
 

--- a/packages/keychain/src/components/purchase/index.tsx
+++ b/packages/keychain/src/components/purchase/index.tsx
@@ -70,7 +70,7 @@ export function Purchase({
   starterpackDetails,
   initState = PurchaseState.SELECTION,
 }: PurchaseCreditsProps) {
-  const { controller, closeModal, policies } = useConnection();
+  const { controller, closeModal } = useConnection();
   const {
     isLoading: isLoadingWallets,
     error: walletError,
@@ -90,22 +90,6 @@ export function Purchase({
   const [selectedWallet, setSelectedWallet] = useState<ExternalWallet>();
   const [walletAddress, setWalletAddress] = useState<string>();
   const [displayError, setDisplayError] = useState<Error | null>(null);
-  const [hasValidSession, setHasValidSession] = useState<boolean>(false);
-
-  useEffect(() => {
-    if (!controller || !policies) {
-      return;
-    }
-    controller.isRequestedSession(policies).then((isValid) => {
-      setHasValidSession(isValid);
-
-      if (!isValid) {
-        setDisplayError(
-          new Error("No active session, please logout and login again"),
-        );
-      }
-    });
-  }, [controller, policies]);
 
   const {
     stripePromise,
@@ -321,7 +305,7 @@ export function Purchase({
             Close
           </Button>
         )}
-        {state === PurchaseState.SELECTION && hasValidSession && (
+        {state === PurchaseState.SELECTION && (
           <PurchaseActions
             starterpackDetails={starterpackDetails}
             isStripeLoading={isStripeLoading}


### PR DESCRIPTION
Not able to determine if there's an active session policy this way. Use connection hook defaults to Sepolia and the policies returned are always null for Eternum mainnet. Will need to find another solution.

This reverts commit ba70b1c.