### PR TITLE
Fix/several minor fixes

### DIFF
--- a/examples/next/src/components/providers/StarknetProvider.tsx
+++ b/examples/next/src/components/providers/StarknetProvider.tsx
@@ -174,9 +174,7 @@ const controller = new ControllerConnector({
   slot: "eternum",
   preset: "eternum",
   tokens: {
-    erc20: [
-      "0x0124aeb495b947201f5fac96fd1138e326ad86195b98df6dec9009158a533b49",
-    ],
+    erc20: ["lords"],
   },
 });
 

--- a/packages/controller/src/iframe/profile.ts
+++ b/packages/controller/src/iframe/profile.ts
@@ -20,7 +20,6 @@ export class ProfileIFrame extends IFrame<Profile> {
     slot,
     namespace,
     tokens,
-    policies,
     ...iframeOptions
   }: ProfileIFrameOptions) {
     const _profileUrl = (profileUrl || PROFILE_URL).replace(/\/$/, "");
@@ -48,16 +47,6 @@ export class ProfileIFrame extends IFrame<Profile> {
       _url.searchParams.set(
         "erc20",
         encodeURIComponent(tokens.erc20.toString()),
-      );
-    }
-
-    if (policies?.contracts) {
-      const methods = Object.values(policies.contracts).flatMap(
-        (contract) => contract.methods,
-      );
-      _url.searchParams.set(
-        "methods",
-        encodeURIComponent(JSON.stringify(methods)),
       );
     }
 

--- a/packages/controller/src/types.ts
+++ b/packages/controller/src/types.ts
@@ -227,8 +227,6 @@ export type ProfileOptions = IFrameOptions & {
   namespace?: string;
   /** The tokens to be listed on Inventory modal */
   tokens?: Tokens;
-  /** The policies to use for the profile */
-  policies?: SessionPolicies;
 };
 
 export type ProfileContextTypeVariant =
@@ -238,6 +236,8 @@ export type ProfileContextTypeVariant =
   | "leaderboard"
   | "activity";
 
+export type Token = "eth" | "strk" | "lords" | "usdc" | "usdt";
+
 export type Tokens = {
-  erc20?: string[];
+  erc20?: Token[];
 };

--- a/packages/keychain/src/components/purchase/index.tsx
+++ b/packages/keychain/src/components/purchase/index.tsx
@@ -1,5 +1,5 @@
 import { ErrorAlert } from "@/components/ErrorAlert";
-import { useConnection, useConnectionValue } from "@/hooks/connection";
+import { useConnection } from "@/hooks/connection";
 import { useWallets } from "@/hooks/wallets";
 import {
   Button,
@@ -71,7 +71,6 @@ export function Purchase({
   initState = PurchaseState.SELECTION,
 }: PurchaseCreditsProps) {
   const { controller, closeModal } = useConnection();
-  const { policies } = useConnectionValue();
   const {
     isLoading: isLoadingWallets,
     error: walletError,
@@ -91,23 +90,6 @@ export function Purchase({
   const [selectedWallet, setSelectedWallet] = useState<ExternalWallet>();
   const [walletAddress, setWalletAddress] = useState<string>();
   const [displayError, setDisplayError] = useState<Error | null>(null);
-  const [hasValidSession, setHasValidSession] = useState<boolean>(false);
-
-  useEffect(() => {
-    if (!controller || !policies) {
-      return;
-    }
-
-    controller.isRequestedSession(policies).then((isValid) => {
-      setHasValidSession(isValid);
-
-      if (!isValid) {
-        setDisplayError(
-          new Error("No active session, please logout and login again"),
-        );
-      }
-    });
-  }, [controller, policies]);
 
   const {
     stripePromise,
@@ -323,7 +305,7 @@ export function Purchase({
             Close
           </Button>
         )}
-        {state === PurchaseState.SELECTION && hasValidSession && (
+        {state === PurchaseState.SELECTION && (
           <PurchaseActions
             starterpackDetails={starterpackDetails}
             isStripeLoading={isStripeLoading}

--- a/packages/profile/src/components/inventory/token/token.tsx
+++ b/packages/profile/src/components/inventory/token/token.tsx
@@ -12,18 +12,16 @@ import {
   LayoutFooter,
   LayoutHeader,
   Button,
-  Card,
-  CardContent,
-  CoinsIcon,
   ActivityTokenCard,
   ERC20Detail,
   ERC20Header,
   PaperPlaneIcon,
+  Thumbnail,
+  InfoIcon,
 } from "@cartridge/ui";
 import { useConnection, useData } from "#hooks/context";
 import {
   getDate,
-  isIframe,
   isPublicChain,
   useCreditBalance,
   VoyagerUrl,
@@ -56,36 +54,40 @@ function Credits() {
   const { username } = useAccount();
   const credit = useCreditBalance({
     username,
-    interval: isVisible ? 3000 : undefined,
+    interval: isVisible ? 30000 : undefined,
   });
 
   return (
     <LayoutContainer>
       <LayoutHeader
-        title={`${credit.balance} CREDITS`}
-        description={`$${credit.balance}`}
-        icon={<CoinsIcon variant="solid" size="lg" />}
+        variant="hidden"
         onBack={() => {
           navigate("..");
         }}
       />
 
-      <LayoutContent className="pb-4">
-        <Card>
-          <CardContent className="flex items-center justify-between">
-            <div className="text-foreground-400">
-              Credits are used to pay for network activity. They are not tokens
-              and cannot be transferred or refunded.
-            </div>
-          </CardContent>
-        </Card>
+      <LayoutContent className="pb-4 gap-6">
+        <div className="flex gap-4 items-center">
+          <Thumbnail
+            icon="https://static.cartridge.gg/presets/credit/icon.svg"
+            size="lg"
+            rounded
+          />
+          <p className="text-foreground-100 text-lg/6 font-semibold">{`${credit.balance.value} CREDITS`}</p>
+        </div>
+
+        <div className="flex gap-1 bg-background-125 border border-background-200 px-3 py-2.5 rounded text-foreground-300">
+          <InfoIcon size="sm" className="min-w-5" />
+          <p className="px-1 text-xs">
+            Credits are used to pay for network activity. They are not tokens
+            and cannot be transferred or refunded.
+          </p>
+        </div>
       </LayoutContent>
 
-      {isIframe() && (
-        <LayoutFooter>
-          <Button onClick={() => parent.openPurchaseCredits()}>Purchase</Button>
-        </LayoutFooter>
-      )}
+      <LayoutFooter className="gap-4">
+        <Button onClick={() => parent.openPurchaseCredits()}>Purchase</Button>
+      </LayoutFooter>
     </LayoutContainer>
   );
 }
@@ -210,7 +212,7 @@ function ERC20() {
         </div>
       </LayoutContent>
 
-      {isIframe() && compatibility && !visitor && (
+      {compatibility && !visitor && (
         <LayoutFooter>
           <Link to={`send?${searchParams.toString()}`} className="w-full">
             <Button className="w-full space-x-2">

--- a/packages/profile/src/components/inventory/token/tokens.tsx
+++ b/packages/profile/src/components/inventory/token/tokens.tsx
@@ -25,7 +25,7 @@ export function Tokens() {
 
   return status === "loading" ? (
     <LoadingState />
-  ) : status === "error" || !tokens.length ? (
+  ) : status === "error" ? (
     <EmptyState />
   ) : (
     <div

--- a/packages/profile/src/components/inventory/token/tokens.tsx
+++ b/packages/profile/src/components/inventory/token/tokens.tsx
@@ -1,10 +1,27 @@
-import { Empty, Skeleton, TokenCard } from "@cartridge/ui";
+import { Empty, MinusIcon, PlusIcon, Skeleton, TokenCard } from "@cartridge/ui";
 import { Link } from "react-router-dom";
 import { Token, useTokens } from "#hooks/token";
 import placeholder from "/public/placeholder.svg";
+import { useEffect, useMemo, useState } from "react";
+import { useConnection } from "#hooks/context.js";
+import { cn } from "@cartridge/ui/utils";
+
+const DEFAULT_TOKENS_COUNT = 2;
 
 export function Tokens() {
-  const { tokens, status } = useTokens();
+  const { isVisible } = useConnection();
+  const { tokens, credits, status } = useTokens();
+  const [unfolded, setUnfolded] = useState(false);
+
+  const filteredTokens = useMemo(() => {
+    return tokens
+      .filter((token) => token.balance.amount > 0)
+      .sort((a, b) => b.balance.value - a.balance.value);
+  }, [tokens]);
+
+  useEffect(() => {
+    setUnfolded(false);
+  }, [isVisible]);
 
   return status === "loading" ? (
     <LoadingState />
@@ -15,11 +32,29 @@ export function Tokens() {
       className="rounded overflow-clip w-full flex flex-col gap-y-px"
       style={{ scrollbarWidth: "none" }}
     >
-      {tokens
-        .filter((token) => token.balance.amount > 0)
+      <TokenCardContent token={credits} />
+      {filteredTokens
+        .slice(0, unfolded ? tokens.length : DEFAULT_TOKENS_COUNT)
         .map((token) => (
           <TokenCardContent key={token.metadata.address} token={token} />
         ))}
+      <div
+        className={cn(
+          "flex justify-center items-center gap-1 p-2 rounded-b cursor-pointer",
+          "bg-background-200 hover:bg-background-300 text-foreground-300 hover:text-foreground-200",
+          tokens.length <= DEFAULT_TOKENS_COUNT && "hidden",
+        )}
+        onClick={() => setUnfolded(!unfolded)}
+      >
+        {unfolded ? (
+          <MinusIcon size="xs" />
+        ) : (
+          <PlusIcon variant="solid" size="xs" />
+        )}
+        <p className="text-sm font-medium">
+          {unfolded ? "Show Less" : "View All"}
+        </p>
+      </div>
     </div>
   );
 }

--- a/packages/profile/src/components/provider/connection.tsx
+++ b/packages/profile/src/components/provider/connection.tsx
@@ -1,13 +1,6 @@
 import { connectToParent } from "@cartridge/penpal";
 import { useState, ReactNode, useEffect, useCallback } from "react";
-import {
-  ETH_CONTRACT_ADDRESS,
-  normalize,
-  STRK_CONTRACT_ADDRESS,
-  USDC_CONTRACT_ADDRESS,
-  USDT_CONTRACT_ADDRESS,
-  DAI_CONTRACT_ADDRESS,
-} from "@cartridge/ui/utils";
+import { normalize, STRK_CONTRACT_ADDRESS } from "@cartridge/ui/utils";
 import { constants, getChecksumAddress, hash, RpcProvider } from "starknet";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import {
@@ -62,23 +55,15 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
       if (!state.erc20.length) {
         const erc20Param = searchParams.get("erc20");
         state.erc20 = [
-          ETH_CONTRACT_ADDRESS,
           STRK_CONTRACT_ADDRESS,
-          USDC_CONTRACT_ADDRESS,
-          USDT_CONTRACT_ADDRESS,
-          DAI_CONTRACT_ADDRESS,
           ...(erc20Param
             ? decodeURIComponent(erc20Param)
                 .split(",")
                 .filter(
                   (address) =>
-                    ![
-                      ETH_CONTRACT_ADDRESS,
-                      STRK_CONTRACT_ADDRESS,
-                      USDC_CONTRACT_ADDRESS,
-                      USDT_CONTRACT_ADDRESS,
-                      DAI_CONTRACT_ADDRESS,
-                    ].includes(getChecksumAddress(address)),
+                    ![STRK_CONTRACT_ADDRESS].includes(
+                      getChecksumAddress(address),
+                    ),
                 )
             : []),
         ];

--- a/packages/profile/src/components/provider/connection.tsx
+++ b/packages/profile/src/components/provider/connection.tsx
@@ -1,7 +1,13 @@
 import { connectToParent } from "@cartridge/penpal";
 import { useState, ReactNode, useEffect, useCallback } from "react";
-import { normalize, STRK_CONTRACT_ADDRESS } from "@cartridge/ui/utils";
-import { constants, getChecksumAddress, hash, RpcProvider } from "starknet";
+import {
+  normalize,
+  STRK_CONTRACT_ADDRESS,
+  ETH_CONTRACT_ADDRESS,
+  USDC_CONTRACT_ADDRESS,
+  USDT_CONTRACT_ADDRESS,
+} from "@cartridge/ui/utils";
+import { constants, getChecksumAddress, RpcProvider } from "starknet";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import {
   ConnectionContext,
@@ -9,7 +15,20 @@ import {
   ParentMethods,
   initialState,
 } from "#context/connection";
-import { Method } from "@cartridge/presets";
+import { Token } from "@cartridge/controller";
+
+// FIXME: rely on the one in ui once available
+const LORDS_CONTRACT_ADDRESS = getChecksumAddress(
+  "0x0124aeb495b947201f5fac96fd1138e326ad86195b98df6dec9009158a533b49",
+);
+
+const TOKEN_ADDRESSES: Record<Token, string> = {
+  eth: ETH_CONTRACT_ADDRESS,
+  strk: STRK_CONTRACT_ADDRESS,
+  lords: LORDS_CONTRACT_ADDRESS,
+  usdc: USDC_CONTRACT_ADDRESS,
+  usdt: USDT_CONTRACT_ADDRESS,
+};
 
 export function ConnectionProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<ConnectionContextType>(initialState);
@@ -54,34 +73,14 @@ export function ConnectionProvider({ children }: { children: ReactNode }) {
       // Only update when erc20 state hasn't been set
       if (!state.erc20.length) {
         const erc20Param = searchParams.get("erc20");
-        state.erc20 = [
-          STRK_CONTRACT_ADDRESS,
-          ...(erc20Param
-            ? decodeURIComponent(erc20Param)
-                .split(",")
-                .filter(
-                  (address) =>
-                    ![STRK_CONTRACT_ADDRESS].includes(
-                      getChecksumAddress(address),
-                    ),
-                )
-            : []),
-        ];
+        const addresses = erc20Param
+          ? decodeURIComponent(erc20Param)
+              .split(",")
+              .map((token) => TOKEN_ADDRESSES[token as Token] || null)
+              .filter((address) => address !== null)
+          : [STRK_CONTRACT_ADDRESS];
+        state.erc20 = addresses;
       }
-
-      if (!state.methods.length) {
-        const methodsParam = searchParams.get("methods");
-        if (methodsParam) {
-          const methods: Method[] = JSON.parse(
-            decodeURIComponent(methodsParam),
-          );
-          state.methods = methods.map((method) => ({
-            name: method.name || method.entrypoint,
-            entrypoint: `0x${hash.starknetKeccak(method.entrypoint).toString(16)}`,
-          }));
-        }
-      }
-
       return state;
     });
   }, [searchParams]);

--- a/packages/profile/src/components/provider/data.tsx
+++ b/packages/profile/src/components/provider/data.tsx
@@ -7,7 +7,7 @@ import {
 } from "@cartridge/ui/utils/api/cartridge";
 import { useAccount } from "#hooks/account";
 import { useConnection } from "#hooks/context.js";
-import { getChecksumAddress } from "starknet";
+import { addAddressPadding, getChecksumAddress } from "starknet";
 import { erc20Metadata } from "@cartridge/presets";
 import { useArcade } from "#hooks/arcade.js";
 import { EditionModel, GameModel } from "@bal7hazar/arcade-sdk";
@@ -147,8 +147,8 @@ export function DataProvider({ children }: { children: ReactNode }) {
 
   const erc721s: CardProps[] = useMemo(() => {
     return (
-      transfers?.transfers?.items.flatMap((item) =>
-        item.transfers
+      transfers?.transfers?.items.flatMap((item) => {
+        return item.transfers
           .filter(({ tokenId }) => !!tokenId)
           .map((transfer) => {
             const timestamp = new Date(transfer.executedAt).getTime();
@@ -166,6 +166,7 @@ export function DataProvider({ children }: { children: ReactNode }) {
                 (attribute: { trait: string; value: string }) =>
                   attribute?.trait?.toLowerCase() === "name",
               )?.value || metadata.name;
+            const image = `https://api.cartridge.gg/x/${item.meta.project}/torii/static/0x${BigInt(transfer.contractAddress).toString(16)}/${addAddressPadding(transfer.tokenId)}/image`;
             return {
               variant: "collectible",
               key: `${transfer.transactionHash}-${transfer.eventId}`,
@@ -179,7 +180,7 @@ export function DataProvider({ children }: { children: ReactNode }) {
                   ? transfer.toAddress
                   : transfer.fromAddress,
               value: "",
-              image: metadata.image || "",
+              image: image,
               action:
                 BigInt(transfer.fromAddress) === 0n
                   ? "mint"
@@ -189,8 +190,8 @@ export function DataProvider({ children }: { children: ReactNode }) {
               timestamp: timestamp / 1000,
               date: date,
             } as CardProps;
-          }),
-      ) || []
+          });
+      }) || []
     );
   }, [transfers, address]);
 

--- a/packages/profile/src/hooks/collectible.ts
+++ b/packages/profile/src/hooks/collectible.ts
@@ -56,15 +56,7 @@ export function useCollectible({
       queryKey: ["collectible"],
       enabled: !!project && !!address,
       onSuccess: ({ collectible }) => {
-        const assets = collectible.assets;
-        const first = assets.length > 0 ? assets[0] : undefined;
-        let metadata: { image?: string } = {};
-        try {
-          metadata = JSON.parse(!first?.metadata ? "{}" : first.metadata);
-        } catch (error) {
-          console.warn(error);
-        }
-        const imageUrl = metadata?.image || collectible.meta.imagePath;
+        const imageUrl = collectible.meta.imagePath;
         const name = collectible.meta.name;
         const newCollectible: Collectible = {
           address: collectible.meta.contractAddress,
@@ -89,18 +81,12 @@ export function useCollectible({
           } catch (error) {
             console.error(error);
           }
-          let metadata: { image?: string } = {};
-          try {
-            metadata = JSON.parse(!a.metadata ? "{}" : a.metadata);
-          } catch (error) {
-            console.warn(error);
-          }
           const name = a.name;
           const asset: Asset = {
             tokenId: a.tokenId,
             name: name ? name : "---",
             description: a.description ?? "",
-            imageUrl: metadata?.image ?? imageUrl,
+            imageUrl: imageUrl,
             attributes: attributes,
             amount: a.amount,
           };

--- a/packages/profile/src/hooks/collection.ts
+++ b/packages/profile/src/hooks/collection.ts
@@ -55,24 +55,17 @@ export function useCollection({
       queryKey: ["collection"],
       enabled: !!project && !!address,
       onSuccess: ({ collection }) => {
-        const assets = collection.assets;
-        const first = assets.length > 0 ? assets[0] : undefined;
-        let metadata: { image?: string } = {};
-        try {
-          metadata = JSON.parse(!first?.metadata ? "{}" : first.metadata);
-        } catch (error) {
-          console.warn(error, { data: first?.metadata });
-        }
         const name = collection.meta.name;
         const newCollection: Collection = {
           address: collection.meta.contractAddress,
           name: name ? name : "---",
           type: TYPE,
-          imageUrl: metadata?.image ?? collection.meta.imagePath,
+          imageUrl: collection.meta.imagePath,
           totalCount: collection.meta.assetCount,
         };
 
         const newAssets: { [key: string]: Asset } = {};
+
         collection.assets.forEach((a) => {
           let imageUrl = a.imageUrl;
           if (!imageUrl.includes("://")) {
@@ -97,7 +90,7 @@ export function useCollection({
             tokenId: a.tokenId,
             name: a.name,
             description: a.description ?? "",
-            imageUrl: metadata?.image ?? imageUrl,
+            imageUrl: imageUrl || metadata?.image || "",
             attributes: attributes,
           };
           newAssets[`${newCollection.address}-${a.tokenId}`] = asset;
@@ -158,16 +151,9 @@ export function useCollections(): UseCollectionsResponse {
           const imagePath = e.node.meta.imagePath;
           const name = e.node.meta.name;
           const count = e.node.meta.assetCount;
-          const first = e.node.assets.length > 0 ? e.node.assets[0] : undefined;
-          let metadata: { image?: string } = {};
-          try {
-            metadata = JSON.parse(!first?.metadata ? "{}" : first?.metadata);
-          } catch (error) {
-            console.warn(error, { data: first?.metadata });
-          }
           newCollections[`${contractAddress}`] = {
             address: contractAddress,
-            imageUrl: metadata?.image ?? imagePath,
+            imageUrl: imagePath,
             name: name ? name : "---",
             totalCount: count,
             type: TYPE,

--- a/packages/profile/src/hooks/token.mock.ts
+++ b/packages/profile/src/hooks/token.mock.ts
@@ -6,7 +6,7 @@ export * from "./token";
 
 export const credits = {
   balance: {
-    amount: 1,
+    amount: 1.234567,
     value: 0,
     change: 0,
   },
@@ -15,7 +15,7 @@ export const credits = {
     name: "Credits",
     symbol: "CREDITS",
     image: "https://static.cartridge.gg/presets/credit/icon.svg",
-    decimals: 18,
+    decimals: 6,
   },
 };
 

--- a/packages/profile/src/hooks/token.mock.ts
+++ b/packages/profile/src/hooks/token.mock.ts
@@ -4,8 +4,24 @@ import { UseTokensResponse, UseTokenResponse, Token } from "./token";
 
 export * from "./token";
 
+export const credits = {
+  balance: {
+    amount: 1,
+    value: 0,
+    change: 0,
+  },
+  metadata: {
+    address: "credits",
+    name: "Credits",
+    symbol: "CREDITS",
+    image: "https://static.cartridge.gg/presets/credit/icon.svg",
+    decimals: 18,
+  },
+};
+
 export const useTokens: Mock<() => UseTokensResponse> = fn(() => ({
   tokens: Object.values(tokens) as Token[],
+  credits: credits,
   status: "success" as const,
 })).mockName("useTokens");
 

--- a/packages/profile/src/hooks/token.ts
+++ b/packages/profile/src/hooks/token.ts
@@ -99,7 +99,7 @@ export type UseBalancesResponse = {
 
 export function useBalances(accountAddress?: string): UseBalancesResponse {
   const { address: connectedAddress } = useAccount();
-  const { project, erc20 } = useConnection();
+  const { project } = useConnection();
   const [offset, setOffset] = useState(0);
   const [tokens, setTokens] = useState<{ [key: string]: Token }>({});
   const address = useMemo(
@@ -109,7 +109,7 @@ export function useBalances(accountAddress?: string): UseBalancesResponse {
 
   const projects = useMemo(() => {
     return project ? [project, TOKENS_TORII_INSTANCE] : [];
-  }, [project, erc20]);
+  }, [project]);
 
   const { status } = useBalancesQuery(
     {

--- a/packages/profile/src/hooks/token.ts
+++ b/packages/profile/src/hooks/token.ts
@@ -16,7 +16,7 @@ import { erc20Metadata } from "@cartridge/presets";
 import { useUsername } from "./username";
 
 const LIMIT = 1000;
-export const TOKENS_TORII_INSTANCE = "c7e-tokens";
+export const TOKENS_TORII_INSTANCE = "c7e-arcade-tokens";
 
 export type Balance = {
   amount: number;

--- a/packages/profile/src/hooks/token.ts
+++ b/packages/profile/src/hooks/token.ts
@@ -193,7 +193,7 @@ export function useTokens(accountAddress?: string): UseTokensResponse {
       metadata: {
         name: "Credits",
         symbol: "Credits",
-        decimals: 0,
+        decimals: 6,
         address: "credit",
         image: "https://static.cartridge.gg/presets/credit/icon.svg",
       },

--- a/packages/profile/src/hooks/token.ts
+++ b/packages/profile/src/hooks/token.ts
@@ -1,5 +1,6 @@
 import {
   useCountervalue,
+  useCreditBalance,
   useERC20Balance,
   UseERC20BalanceResponse,
 } from "@cartridge/ui/utils";
@@ -12,8 +13,10 @@ import { useConnection } from "./context";
 import { getChecksumAddress } from "starknet";
 import { useMemo, useState } from "react";
 import { erc20Metadata } from "@cartridge/presets";
+import { useUsername } from "./username";
 
 const LIMIT = 1000;
+export const TOKENS_TORII_INSTANCE = "c7e-tokens";
 
 export type Balance = {
   amount: number;
@@ -96,7 +99,7 @@ export type UseBalancesResponse = {
 
 export function useBalances(accountAddress?: string): UseBalancesResponse {
   const { address: connectedAddress } = useAccount();
-  const { project } = useConnection();
+  const { project, erc20 } = useConnection();
   const [offset, setOffset] = useState(0);
   const [tokens, setTokens] = useState<{ [key: string]: Token }>({});
   const address = useMemo(
@@ -104,16 +107,20 @@ export function useBalances(accountAddress?: string): UseBalancesResponse {
     [accountAddress, connectedAddress],
   );
 
+  const projects = useMemo(() => {
+    return project ? [project, TOKENS_TORII_INSTANCE] : [];
+  }, [project, erc20]);
+
   const { status } = useBalancesQuery(
     {
       accountAddress: address,
-      projects: [project ?? ""],
+      projects: projects,
       limit: LIMIT,
       offset: offset,
     },
     {
-      queryKey: ["balances", offset],
-      enabled: !!project && !!address,
+      queryKey: ["balances", offset, projects],
+      enabled: projects.length > 0 && !!address,
       onSuccess: ({ balances }) => {
         const newTokens: { [key: string]: Token } = {};
         balances?.edges.forEach((e) => {
@@ -160,19 +167,56 @@ export function useBalances(accountAddress?: string): UseBalancesResponse {
   return { tokens: Object.values(tokens), status };
 }
 
-export type UseTokensResponse = UseBalancesResponse;
+export type UseTokensResponse = {
+  tokens: Token[];
+  credits: Token;
+  status: "success" | "error" | "idle" | "loading";
+};
 
 export function useTokens(accountAddress?: string): UseTokensResponse {
   const { erc20: options, provider, isVisible } = useConnection();
   const { address } = useAccount();
 
+  // Fetch credits
+  const { username } = useUsername({ address });
+  const creditBalance = useCreditBalance({
+    username,
+    interval: isVisible ? 30000 : undefined,
+  });
+  const credits: Token = useMemo(() => {
+    return {
+      balance: {
+        amount: Number(creditBalance.balance.value),
+        value: 0,
+        change: 0,
+      },
+      metadata: {
+        name: "Credits",
+        symbol: "Credits",
+        decimals: 0,
+        address: "credit",
+        image: "https://static.cartridge.gg/presets/credit/icon.svg",
+      },
+    };
+  }, [creditBalance]);
+
   // Get token data from torii
   const toriiData = useBalances(accountAddress);
 
-  // Get token data from rpc (based on url options)
+  // Get token data from rpc (based on url options without those fetched from torii)
+  const contractAddress = useMemo(() => {
+    if (toriiData.status !== "success") return [];
+    return options.filter(
+      (token) =>
+        !toriiData.tokens.find(
+          (t) => BigInt(t.metadata.address || "0x0") === BigInt(token),
+        ),
+    );
+  }, [options, toriiData]);
+
   const { data: rpcData }: UseERC20BalanceResponse = useERC20Balance({
     address: accountAddress ?? address,
-    contractAddress: options,
+    contractAddress: contractAddress,
     provider,
     interval: isVisible ? 30000 : undefined,
   });
@@ -184,7 +228,9 @@ export function useTokens(accountAddress?: string): UseTokensResponse {
         .filter(
           (token) =>
             !toriiData.tokens.find(
-              (t) => BigInt(t.metadata.address) === BigInt(token.meta.address),
+              (t) =>
+                BigInt(t.metadata.address || "0x0") ===
+                BigInt(token.meta.address),
             ),
         )
         .map((token) => ({
@@ -195,12 +241,15 @@ export function useTokens(accountAddress?: string): UseTokensResponse {
   );
 
   // Get prices for filtered tokens
-  const { countervalues } = useCountervalue({
-    tokens: tokenData,
-  });
+  const { countervalues } = useCountervalue(
+    {
+      tokens: tokenData,
+    },
+    { enabled: isVisible },
+  );
 
   // Merge data
-  const data = useMemo(() => {
+  const tokens = useMemo(() => {
     const newData: UseBalancesResponse = { tokens: [], status: "success" };
     // Use a map to track tokens by their normalized address
     const tokenMap: Record<string, Token> = {};
@@ -236,7 +285,9 @@ export function useTokens(accountAddress?: string): UseTokensResponse {
 
     // Process tokens from toriiData
     toriiData.tokens.forEach((token) => {
-      const normalizedAddress = BigInt(token.metadata.address).toString();
+      const normalizedAddress = BigInt(
+        token.metadata.address || "0x0",
+      ).toString();
       // Only add if we don't already have this token
       if (!tokenMap[normalizedAddress]) {
         tokenMap[normalizedAddress] = token;
@@ -248,7 +299,7 @@ export function useTokens(accountAddress?: string): UseTokensResponse {
     newData.status = toriiData.status;
     return newData;
   }, [rpcData, toriiData, countervalues]);
-  return data;
+  return { tokens: tokens.tokens, credits, status: tokens.status };
 }
 
 export type UseTokenResponse = UseBalanceResponse;
@@ -264,7 +315,7 @@ export function useToken({
   return {
     token: tokens.find(
       (token) =>
-        getChecksumAddress(token.metadata.address) ===
+        getChecksumAddress(token.metadata.address || "0x0") ===
         getChecksumAddress(tokenAddress),
     ),
     status,


### PR DESCRIPTION
- Added Credits to the Inventory (such as it is in Arcade)
- Added the ability to unfold (starts at 3 and more to not break the first NFT row)
- Rework the Credit page which was outdated, it matches the design now (except credits $value in the header, which is outdated in the design iirc)
- By default only Credits and STRK, can be overridden with the `tokens: { erc20: ("eth" | "strk" | "lords" | "usdc" | "usdt")[] }` Profile option
- We use our internal toriis to get ETH, STRK, USDC/T and LORDS, there is still a fetch balance for all tokens remaining (but a fetch every 30s instead of 3s and disabled when the iframe is closed)
- Fixed Chaos Surfers images