### PR TITLE
fix: error handling for bundle decryption + signup account issue

### DIFF
--- a/packages/keychain/src/components/connect/create/social/api.ts
+++ b/packages/keychain/src/components/connect/create/social/api.ts
@@ -1,5 +1,6 @@
 import { fetchApiCreator } from "@cartridge/ui/utils";
 import { TurnkeyIframeClient } from "@turnkey/sdk-browser";
+import { getIframePublicKey } from "./index";
 
 export const SOCIAL_PROVIDER_NAME = "discord";
 
@@ -10,17 +11,15 @@ export const fetchApi = fetchApiCreator(
   },
 );
 
-export const getTurnkeySuborg = async (oidcToken: string) => {
+export const getTurnkeySuborg = async (
+  oidcToken: string,
+): Promise<string | undefined> => {
   const getSuborgsResponse = await fetchApi<GetSuborgsResponse>("suborgs", {
     filterType: "OIDC_TOKEN",
     filterValue: oidcToken,
   });
   if (!getSuborgsResponse) {
     throw new Error("No suborgs response found");
-  }
-
-  if (getSuborgsResponse.organizationIds.length === 0) {
-    throw new Error("No suborgs found");
   }
 
   if (getSuborgsResponse.organizationIds.length > 1) {
@@ -71,11 +70,13 @@ export const authenticateToTurnkey = async (
   oidcToken: string,
   authIframeClient: TurnkeyIframeClient,
 ) => {
+  const iframePublicKey = await getIframePublicKey(authIframeClient);
+
   const authResponse = await fetchApi<AuthResponse>(
     `auth`,
     {
       suborgID: subOrgId,
-      targetPublicKey: authIframeClient.iframePublicKey,
+      targetPublicKey: iframePublicKey,
       oidcToken,
       invalidateExisting: true,
     },

--- a/packages/keychain/src/components/connect/create/social/auth0.ts
+++ b/packages/keychain/src/components/connect/create/social/auth0.ts
@@ -4,7 +4,7 @@ import { jwtDecode, JwtPayload } from "jwt-decode";
 export const getOidcToken = async (
   getIdTokenClaims: () => Promise<IdToken | undefined>,
   expectedNonce: string,
-): Promise<string | undefined> => {
+) => {
   const tokenClaims = await getIdTokenClaims();
   if (!tokenClaims) {
     throw new Error("Not authenticated with Auth0 yet");


### PR DESCRIPTION
Adds better error handling for bundle decryption of embedded public key bug of turnkey (`Uncaught (in promise) Error: Error: unable to decrypt bundle using embedded key. the bundle may be incorrect. failed with error: M`)

Also fixes signup issues: if a user was already connected to his discord account on the keychain and went through the OAuth process to create a new controller, but logged in to a different account on Discord he would still be connected to the initial account