### PR TITLE
Fix blank screen on manual execute after update session

### DIFF
--- a/packages/keychain/src/components/home.tsx
+++ b/packages/keychain/src/components/home.tsx
@@ -4,7 +4,6 @@ import { ResponseCodes } from "@cartridge/controller";
 import { useConnection } from "@/hooks/connection";
 import {
   DeployCtx,
-  ExecuteCtx,
   OpenStarterPackCtx,
   SignMessageCtx,
 } from "@/utils/connection";
@@ -16,14 +15,13 @@ import { Purchase } from "./purchase";
 import { Settings } from "./settings";
 import { SignMessage } from "./SignMessage";
 import { PageLoading } from "./Loading";
-import { execute } from "@/utils/connection/execute";
 import { useUpgrade } from "./provider/upgrade";
 import { usePostHog } from "./provider/posthog";
 import { StarterPack } from "./starterpack";
 import { PurchaseType } from "@/hooks/payments/crypto";
 
 export function Home() {
-  const { context, setContext, controller, policies, origin, isConfigLoading } =
+  const { context, controller, policies, origin, isConfigLoading } =
     useConnection();
   const upgrade = useUpgrade();
   const [hasSessionForPolicies, setHasSessionForPolicies] = useState<
@@ -119,30 +117,12 @@ export function Home() {
     }
 
     case "execute": {
-      const ctx = context as ExecuteCtx;
       if (!hasSessionForPolicies) {
         return (
           <CreateSession
             isUpdate
             policies={policies!}
-            onConnect={async () => {
-              const res = await execute({
-                setContext: (nextCtx) => {
-                  setContext(nextCtx);
-                },
-              })(ctx.transactions, undefined, undefined, false);
-
-              setHasSessionForPolicies(true);
-
-              if ("transaction_hash" in res) {
-                // resets execute ui
-                setContext(undefined);
-                return ctx.resolve?.({
-                  code: ResponseCodes.SUCCESS,
-                  transaction_hash: res.transaction_hash,
-                });
-              }
-            }}
+            onConnect={() => setHasSessionForPolicies(true)}
           />
         );
       }


### PR DESCRIPTION
During manual execution flow, if the session is expired we first show the update session dialog. However, we're losing original context by calling `execute` again when user hits update. This results in a blank screen. This is highly reproducible with pistols.gg

Fix is to use the original `execute` context. But I'm not sure why we were doing it the other way in the first place, perhaps some edge case I'm not aware of cc @tarrencev 