### PR TITLE
fix: connection destroyed on navigate

### DIFF
--- a/packages/keychain/src/hooks/connection.ts
+++ b/packages/keychain/src/hooks/connection.ts
@@ -481,14 +481,7 @@ export function useConnectionValue() {
           iframeMethods.externalWaitForTransaction(currentOrigin),
       });
     }
-  }, [
-    setOrigin,
-    setRpcUrl,
-    setContext,
-    setController,
-    setConfigSignupOptions,
-    navigate,
-  ]);
+  }, []); // Empty dependency array since we only want to run this once
 
   const logout = useCallback(async () => {
     await window.controller?.disconnect();


### PR DESCRIPTION
Including `navigate` here triggers a new penpal connection on navigate call, breaking the channel. Causes an error like this when requesting external wallet chain switch:

`Error: Unable to send externalSwitchChain() call due to destroyed connection`