### PR TITLE
feat: add lazyload option to defer iframe mounting

### DIFF
--- a/packages/controller/src/types.ts
+++ b/packages/controller/src/types.ts
@@ -86,7 +86,7 @@ export type DeployReply = {
 };
 
 export type IFrames = {
-  keychain: KeychainIFrame;
+  keychain?: KeychainIFrame;
   version?: number;
 };
 
@@ -228,6 +228,8 @@ export type KeychainOptions = IFrameOptions & {
   namespace?: string;
   /** The tokens to be listed on Inventory modal */
   tokens?: Tokens;
+  /** When true, defer iframe mounting until connect() is called. Reduces initial load and resource fetching. */
+  lazyload?: boolean;
 };
 
 export type ProfileContextTypeVariant =


### PR DESCRIPTION
Add optional lazyload parameter to ControllerOptions that defers keychain iframe mounting until connect() is called. This reduces initial load time and prevents unnecessary resource fetching when the controller is instantiated but not immediately used.

- Add lazyload option to KeychainOptions interface
- Make IFrames.keychain optional to support lazy initialization
- Extract createKeychainIframe() method for reusable iframe creation
- Update connect() and probe() to ensure iframe exists before use
- Add null safety checks in async callbacks

🤖 Generated with [Claude Code](https://claude.ai/code)