### PR TITLE
Remove starknetkit dependency and use raw starknet.js

### DIFF
--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -36,8 +36,7 @@
     "@metamask/sdk": "^0.32.1",
     "@solana/web3.js": "catalog:",
     "open": "^10.1.0",
-    "starknet": "^8.5.2",
-    "starknetkit": "^3.0.3"
+    "starknet": "^8.5.2"
   },
   "dependencies": {
     "@cartridge/controller-wasm": "catalog:",

--- a/packages/controller/src/__tests__/setup.ts
+++ b/packages/controller/src/__tests__/setup.ts
@@ -1,14 +1,10 @@
 // Jest setup file to handle cleanup of timers and open handles
 
-// Mock starknetkit to prevent it from creating timers
-jest.mock("starknetkit", () => ({
-  connect: jest.fn(),
-  StarknetWindowObject: {},
-}));
-
-jest.mock("starknetkit/injected", () => ({
-  InjectedConnector: jest.fn(),
-}));
+// Mock window.starknet objects for wallet tests
+if (typeof window !== "undefined") {
+  (window as any).starknet_argentX = undefined;
+  (window as any).starknet_braavos = undefined;
+}
 
 // Clean up any remaining timers after each test
 afterEach(() => {

--- a/packages/controller/src/wallets/argent/index.ts
+++ b/packages/controller/src/wallets/argent/index.ts
@@ -1,6 +1,4 @@
-import { Call, TypedData } from "@starknet-io/types-js";
-import { connect, StarknetWindowObject } from "starknetkit";
-import { InjectedConnector } from "starknetkit/injected";
+import { Call, TypedData, StarknetWindowObject } from "@starknet-io/types-js";
 import {
   ExternalPlatform,
   ExternalWallet,
@@ -45,16 +43,24 @@ export class ArgentWallet implements WalletAdapter {
         throw new Error("Argent is not available");
       }
 
-      const { wallet, connectorData } = await connect({
-        connectors: [new InjectedConnector({ options: { id: "argentX" } })],
-      });
-
+      const wallet = window.starknet_argentX as StarknetWindowObject;
       if (!wallet) {
         throw new Error("No wallet found");
       }
 
+      // Request accounts from the wallet
+      const accounts = await wallet.request({
+        type: "wallet_requestAccounts",
+        params: { silent_mode: false },
+      });
+
+      if (!accounts || accounts.length === 0) {
+        throw new Error("No accounts found");
+      }
+
       this.wallet = wallet;
-      this.account = connectorData?.account;
+      this.account = accounts[0];
+      this.connectedAccounts = accounts;
       return { success: true, wallet: this.type, account: this.account };
     } catch (error) {
       console.error(`Error connecting to Argent:`, error);

--- a/packages/controller/src/wallets/braavos/index.ts
+++ b/packages/controller/src/wallets/braavos/index.ts
@@ -1,6 +1,4 @@
-import { Call, TypedData } from "@starknet-io/types-js";
-import { connect, StarknetWindowObject } from "starknetkit";
-import { InjectedConnector } from "starknetkit/injected";
+import { Call, TypedData, StarknetWindowObject } from "@starknet-io/types-js";
 import {
   ExternalPlatform,
   ExternalWallet,
@@ -45,16 +43,24 @@ export class BraavosWallet implements WalletAdapter {
         throw new Error("Braavos is not available");
       }
 
-      const { wallet, connectorData } = await connect({
-        connectors: [new InjectedConnector({ options: { id: "braavos" } })],
-      });
-
+      const wallet = window.starknet_braavos as StarknetWindowObject;
       if (!wallet) {
         throw new Error("No wallet found");
       }
 
+      // Request accounts from the wallet
+      const accounts = await wallet.request({
+        type: "wallet_requestAccounts",
+        params: { silent_mode: false },
+      });
+
+      if (!accounts || accounts.length === 0) {
+        throw new Error("No accounts found");
+      }
+
       this.wallet = wallet;
-      this.account = connectorData?.account;
+      this.account = accounts[0];
+      this.connectedAccounts = accounts;
       return { success: true, wallet: this.type, account: this.account };
     } catch (error) {
       console.error(`Error connecting to Braavos:`, error);

--- a/packages/controller/vite.config.js
+++ b/packages/controller/vite.config.js
@@ -13,7 +13,6 @@ const externalDeps = [
   "@metamask/sdk", 
   "open",
   "starknet",
-  "starknetkit", 
 ];
 
 export default defineConfig(({ mode }) => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,9 +422,6 @@ importers:
       starknet:
         specifier: ^7.6.2
         version: 7.6.2
-      starknetkit:
-        specifier: ^3.0.3
-        version: 3.0.3(79ed08960aa30cf183d6b9bb837e8388)
     devDependencies:
       '@cartridge/tsconfig':
         specifier: workspace:*


### PR DESCRIPTION
## Summary
- Removed starknetkit dependency in favor of direct starknet.js usage
- Updated ArgentWallet and BraavosWallet to use window.starknet objects directly
- Simplified wallet connection logic by removing unnecessary abstraction layer

## Changes
- **ArgentWallet**: Now directly accesses `window.starknet_argentX` and uses `wallet_requestAccounts` 
- **BraavosWallet**: Now directly accesses `window.starknet_braavos` and uses `wallet_requestAccounts`
- **Dependencies**: Removed starknetkit from package.json and vite.config.js
- **Tests**: Updated test setup to remove starknetkit mocks
- **Types**: Using `StarknetWindowObject` from `@starknet-io/types-js` (already a dependency)

## Benefits
✅ One less dependency to maintain
✅ Direct control over wallet connection logic
✅ Better integration with starknet.js ecosystem
✅ Simpler, more maintainable code

## Test plan
- [x] Build passes successfully
- [x] Linting and formatting pass
- [ ] Test wallet connections with Argent wallet
- [ ] Test wallet connections with Braavos wallet
- [ ] Verify transaction signing still works
- [ ] Ensure chain switching functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)