### PR TITLE
Add error parsing tests for 'Not active' and ENTRYPOINT_NOT_FOUND cases

### DIFF
--- a/packages/keychain/src/utils/errors.rpc.test.ts
+++ b/packages/keychain/src/utils/errors.rpc.test.ts
@@ -160,9 +160,15 @@ describe("parseExecutionError - RPC Nested Error Format", () => {
 
     expect(result.summary).toBe("Not active");
     expect(result.stack[0].error).toEqual(["Not active"]);
-    expect(result.stack[0].address).toBe("0x4bb778faff2bfcc23e97b3a184c9658e8048351ab68dc56e1f493bac3b20794");
-    expect(result.stack[0].class).toBe("0x743c83c41ce99ad470aa308823f417b2141e02e04571f5c0004e743556e7faf");
-    expect(result.stack[0].selector).toBe("0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad");
+    expect(result.stack[0].address).toBe(
+      "0x4bb778faff2bfcc23e97b3a184c9658e8048351ab68dc56e1f493bac3b20794",
+    );
+    expect(result.stack[0].class).toBe(
+      "0x743c83c41ce99ad470aa308823f417b2141e02e04571f5c0004e743556e7faf",
+    );
+    expect(result.stack[0].selector).toBe(
+      "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+    );
   });
 
   it("should handle ENTRYPOINT_NOT_FOUND with empty error and display generic message", () => {
@@ -179,8 +185,14 @@ describe("parseExecutionError - RPC Nested Error Format", () => {
     const result = parseExecutionError(error, 0);
 
     expect(result.summary).toBe("Transaction execution failed");
-    expect(result.stack[0].address).toBe("0x04fdcb829582d172a6f3858b97c16da38b08da5a1df7101a5d285b868d89921b");
-    expect(result.stack[0].class).toBe("0x0743c83c41ce99ad470aa308823f417b2141e02e04571f5c0004e743556e7faf");
-    expect(result.stack[0].selector).toBe("0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad");
+    expect(result.stack[0].address).toBe(
+      "0x04fdcb829582d172a6f3858b97c16da38b08da5a1df7101a5d285b868d89921b",
+    );
+    expect(result.stack[0].class).toBe(
+      "0x0743c83c41ce99ad470aa308823f417b2141e02e04571f5c0004e743556e7faf",
+    );
+    expect(result.stack[0].selector).toBe(
+      "0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+    );
   });
 });

--- a/packages/keychain/src/utils/errors.rpc.test.ts
+++ b/packages/keychain/src/utils/errors.rpc.test.ts
@@ -144,4 +144,43 @@ describe("parseExecutionError - RPC Nested Error Format", () => {
     // Since the Nested error format is malformed, it should be processed as a regular error
     expect(result.raw).toBe("Contract address= 0x888, Nested error: malformed");
   });
+
+  it("should parse 'Not active' error correctly", () => {
+    const error = {
+      code: 41,
+      message: "Transaction execution error",
+      data: {
+        transaction_index: 0,
+        execution_error:
+          "Contract address= 0x4bb778faff2bfcc23e97b3a184c9658e8048351ab68dc56e1f493bac3b20794, Class hash= 0x743c83c41ce99ad470aa308823f417b2141e02e04571f5c0004e743556e7faf, Selector= 0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad, Nested error: (0x617267656e742f6d756c746963616c6c2d6661696c6564 ('argent/multicall-failed'), 0x4e6f7420616374697665 ('Not active'), 0x454e545259504f494e545f4641494c4544 ('ENTRYPOINT_FAILED'))",
+      },
+    };
+
+    const result = parseExecutionError(error, 0);
+
+    expect(result.summary).toBe("Not active");
+    expect(result.stack[0].error).toEqual(["Not active"]);
+    expect(result.stack[0].address).toBe("0x4bb778faff2bfcc23e97b3a184c9658e8048351ab68dc56e1f493bac3b20794");
+    expect(result.stack[0].class).toBe("0x743c83c41ce99ad470aa308823f417b2141e02e04571f5c0004e743556e7faf");
+    expect(result.stack[0].selector).toBe("0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad");
+  });
+
+  it("should handle ENTRYPOINT_NOT_FOUND with empty error and display generic message", () => {
+    const error = {
+      code: 41,
+      message: "Transaction execution error",
+      data: {
+        transaction_index: 0,
+        execution_error:
+          "Transaction execution has failed:\n0: Error in the called contract (contract address: 0x04fdcb829582d172a6f3858b97c16da38b08da5a1df7101a5d285b868d89921b, class hash: 0x0743c83c41ce99ad470aa308823f417b2141e02e04571f5c0004e743556e7faf, selector: 0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad):\nExecution failed. Failure reason:\n(0x617267656e742f6d756c746963616c6c2d6661696c6564 ('argent/multicall-failed'), 0x0 (''), 0x454e545259504f494e545f4e4f545f464f554e44 ('ENTRYPOINT_NOT_FOUND'), 0x454e545259504f494e545f4641494c4544 ('ENTRYPOINT_FAILED')).",
+      },
+    };
+
+    const result = parseExecutionError(error, 0);
+
+    expect(result.summary).toBe("Transaction execution failed");
+    expect(result.stack[0].address).toBe("0x04fdcb829582d172a6f3858b97c16da38b08da5a1df7101a5d285b868d89921b");
+    expect(result.stack[0].class).toBe("0x0743c83c41ce99ad470aa308823f417b2141e02e04571f5c0004e743556e7faf");
+    expect(result.stack[0].selector).toBe("0x015d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad");
+  });
 });


### PR DESCRIPTION
## Summary

- Add test case for parsing "Not active" error message from nested error format
- Add test case for ENTRYPOINT_NOT_FOUND with empty error displaying generic message
- Improve error parsing robustness for StarkNet transaction errors

## Changes

- **New test cases**: Added two comprehensive test cases covering different error formats
- **Regex improvements**: Fixed regex patterns to handle empty strings in quoted error tuples
- **Error filtering**: Added ENTRYPOINT_NOT_FOUND to excluded framework errors
- **Fallback message**: Changed from "Multicall failed" to "Transaction execution failed" for better UX

## Test plan

- [x] All existing error parsing tests continue to pass
- [x] New "Not active" test correctly extracts meaningful error message
- [x] New ENTRYPOINT_NOT_FOUND test correctly displays generic message when only framework errors present
- [x] Linting and formatting applied

🤖 Generated with [Claude Code](https://claude.ai/code)