### PR TITLE
feat: add error handling for starterpack edge cases

### DIFF
--- a/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
+++ b/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
@@ -94,7 +94,7 @@ export function StarterPackInner({
             mintAllowance={mintAllowance}
             starterpackItems={starterpackItems}
           />
-          {acquisitionType === StarterpackAcquisitionType.Claimed && (
+          {acquisitionType === StarterpackAcquisitionType.Claimed && !error && (
             <Card>
               <CardContent
                 className="flex flex-row justify-center items-center text-foreground-300 text-sm cursor-pointer h-[40px]"


### PR DESCRIPTION
- Handle "Starterpack not found" query responses with specific error message
- Validate CLAIMED acquisition type with zero merkle drops and disable check eligibility button
- Hide "View Eligible Collections" section when errors occur
- Improve user experience with clear error messaging for edge cases

🤖 Generated with [Claude Code](https://claude.ai/code)