### PR TITLE
fix: remove navigation stack reset in collection components

### DIFF
--- a/packages/keychain/src/components/inventory/collection/collectible-listing.tsx
+++ b/packages/keychain/src/components/inventory/collection/collectible-listing.tsx
@@ -219,7 +219,7 @@ export function CollectibleListing() {
       // Navigate to execute screen with returnTo parameter to come back to the parent page
       const currentPath = `${location.pathname.split("/").slice(0, -1).join("/")}${location.search}`;
       const executeUrlWithReturn = `${executeUrl}&returnTo=${encodeURIComponent(currentPath)}`;
-      navigate(executeUrlWithReturn, { reset: true });
+      navigate(executeUrlWithReturn);
     } catch (error) {
       console.error(error);
       toast.error(`Failed to list asset(s)`);

--- a/packages/keychain/src/components/inventory/collection/collectible-purchase.tsx
+++ b/packages/keychain/src/components/inventory/collection/collectible-purchase.tsx
@@ -228,7 +228,7 @@ export function CollectiblePurchase() {
       // Navigate to execute screen with returnTo parameter to come back to current page
       const currentPath = `${location.pathname.split("/").slice(0, -5).join("/")}${location.search}`;
       const executeUrlWithReturn = `${executeUrl}&returnTo=${encodeURIComponent(currentPath)}`;
-      navigate(executeUrlWithReturn, { reset: true });
+      navigate(executeUrlWithReturn);
     } catch (error) {
       console.error(error);
       toast.error(`Failed to purchase asset(s)`);

--- a/packages/keychain/src/components/inventory/collection/collection-listing.tsx
+++ b/packages/keychain/src/components/inventory/collection/collection-listing.tsx
@@ -199,7 +199,7 @@ export function CollectionListing() {
       // Navigate to execute screen with returnTo parameter to come back to the parent page
       const currentPath = `${location.pathname.split("/").slice(0, -1).join("/")}${location.search}`;
       const executeUrlWithReturn = `${executeUrl}&returnTo=${encodeURIComponent(currentPath)}`;
-      navigate(executeUrlWithReturn, { reset: true });
+      navigate(executeUrlWithReturn);
     } catch (error) {
       console.error(error);
       toast.error(`Failed to list asset(s)`);

--- a/packages/keychain/src/components/inventory/collection/collection-purchase.tsx
+++ b/packages/keychain/src/components/inventory/collection/collection-purchase.tsx
@@ -218,7 +218,7 @@ export function CollectionPurchase() {
       // Navigate to execute screen with returnTo parameter to come back to current page
       const currentPath = `${location.pathname.split("/").slice(0, -5).join("/")}${location.search}`;
       const executeUrlWithReturn = `${executeUrl}&returnTo=${encodeURIComponent(currentPath)}`;
-      navigate(executeUrlWithReturn, { reset: true });
+      navigate(executeUrlWithReturn);
     } catch (error) {
       console.error(error);
       toast.error(`Failed to purchase asset(s)`);


### PR DESCRIPTION
## Summary
- Remove `{ reset: true }` from navigate calls in collection components to preserve navigation stack
- Fixes navigation issue where users couldn't properly navigate back after completing transactions
- Allows proper back navigation after completing transactions with returnTo parameter

## Changes
- **collection-listing.tsx**: Remove reset option from navigate call
- **collectible-listing.tsx**: Remove reset option from navigate call  
- **collection-purchase.tsx**: Remove reset option from navigate call
- **collectible-purchase.tsx**: Remove reset option from navigate call

## Problem
When navigating to execute pages with `{ reset: true }`, the navigation stack was cleared, preventing users from navigating back through their history after transaction completion.

## Solution
By removing the reset option, the navigation stack is preserved:
- Before: `[execute-page]` (history lost)
- After: `[...previous, listing-page, execute-page]` → returns to `[...previous, listing-page]`

This aligns with other similar components that don't use `{ reset: true }` and work correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)