### PR TITLE
feat: add starterpack ID input support to example app

### DIFF
--- a/examples/next/src/components/Starterpack.tsx
+++ b/examples/next/src/components/Starterpack.tsx
@@ -2,7 +2,7 @@
 
 import { useAccount, useNetwork } from "@starknet-react/core";
 import ControllerConnector from "@cartridge/connector/controller";
-import { Button } from "@cartridge/ui";
+import { Button, Input } from "@cartridge/ui";
 import { useState, useEffect, useRef } from "react";
 import { constants, num } from "starknet";
 import { StarterPack, StarterPackItemType } from "@cartridge/controller";
@@ -120,12 +120,12 @@ export const Starterpack = () => {
         <div className="flex flex-col gap-2">
           <h3>Purchase Starterpack</h3>
           <div className="flex items-center gap-2">
-            <input
+            <Input
+              className="max-w-80"
               type="text"
               value={purchaseSpId}
               onChange={(e) => setPurchaseSpId(e.target.value)}
               placeholder="Enter starterpack ID"
-              className="border rounded px-2 py-1 min-w-0 flex-1"
             />
             <Button
               onClick={() => {
@@ -145,12 +145,12 @@ export const Starterpack = () => {
         <div className="flex flex-col gap-2">
           <h3>Claim Starterpack</h3>
           <div className="flex items-center gap-2">
-            <input
+            <Input
+              className="max-w-80"
               type="text"
               value={claimSpId}
               onChange={(e) => setClaimSpId(e.target.value)}
               placeholder="Enter starterpack ID"
-              className="border rounded px-2 py-1 min-w-0 flex-1"
             />
             <Button
               onClick={() => {

--- a/examples/next/src/components/Starterpack.tsx
+++ b/examples/next/src/components/Starterpack.tsx
@@ -3,7 +3,7 @@
 import { useAccount, useNetwork } from "@starknet-react/core";
 import ControllerConnector from "@cartridge/connector/controller";
 import { Button } from "@cartridge/ui";
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { constants, num } from "starknet";
 import { StarterPack, StarterPackItemType } from "@cartridge/controller";
 
@@ -29,6 +29,28 @@ export const Starterpack = () => {
   const defaultIds = getDefaultStarterpackIds();
   const [purchaseSpId, setPurchaseSpId] = useState<string>(defaultIds.purchase);
   const [claimSpId, setClaimSpId] = useState<string>(defaultIds.claim);
+
+  // Track the current expected defaults to detect network changes
+  const expectedDefaultsRef = useRef(defaultIds);
+
+  // Update defaults when network changes, but only if current values match expected defaults
+  useEffect(() => {
+    if (!chain) return;
+
+    const newDefaults = getDefaultStarterpackIds();
+    const currentExpected = expectedDefaultsRef.current;
+
+    // Only update if the values haven't been manually modified by the user
+    if (purchaseSpId === currentExpected.purchase) {
+      setPurchaseSpId(newDefaults.purchase);
+    }
+    if (claimSpId === currentExpected.claim) {
+      setClaimSpId(newDefaults.claim);
+    }
+
+    // Update our reference to the new expected defaults
+    expectedDefaultsRef.current = newDefaults;
+  }, [chain, purchaseSpId, claimSpId]);
 
   if (!account) {
     return null;

--- a/examples/next/src/components/Starterpack.tsx
+++ b/examples/next/src/components/Starterpack.tsx
@@ -32,25 +32,32 @@ export const Starterpack = () => {
 
   // Track the current expected defaults to detect network changes
   const expectedDefaultsRef = useRef(defaultIds);
+  const previousChainRef = useRef(chain);
 
   // Update defaults when network changes, but only if current values match expected defaults
   useEffect(() => {
-    if (!chain) return;
+    if (!chain || chain === previousChainRef.current) return;
 
     const newDefaults = getDefaultStarterpackIds();
     const currentExpected = expectedDefaultsRef.current;
 
     // Only update if the values haven't been manually modified by the user
-    if (purchaseSpId === currentExpected.purchase) {
-      setPurchaseSpId(newDefaults.purchase);
-    }
-    if (claimSpId === currentExpected.claim) {
-      setClaimSpId(newDefaults.claim);
-    }
+    setPurchaseSpId((currentPurchaseSpId) => {
+      return currentPurchaseSpId === currentExpected.purchase
+        ? newDefaults.purchase
+        : currentPurchaseSpId;
+    });
 
-    // Update our reference to the new expected defaults
+    setClaimSpId((currentClaimSpId) => {
+      return currentClaimSpId === currentExpected.claim
+        ? newDefaults.claim
+        : currentClaimSpId;
+    });
+
+    // Update our references after successful comparison and update
     expectedDefaultsRef.current = newDefaults;
-  }, [chain, purchaseSpId, claimSpId]);
+    previousChainRef.current = chain;
+  }, [chain]);
 
   if (!account) {
     return null;

--- a/examples/next/src/components/Starterpack.tsx
+++ b/examples/next/src/components/Starterpack.tsx
@@ -3,33 +3,34 @@
 import { useAccount, useNetwork } from "@starknet-react/core";
 import ControllerConnector from "@cartridge/connector/controller";
 import { Button } from "@cartridge/ui";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { constants, num } from "starknet";
 import { StarterPack, StarterPackItemType } from "@cartridge/controller";
 
 export const Starterpack = () => {
   const { account, connector } = useAccount();
-  const [purchaseSpId, setPurchaseSpId] = useState<string | null>(null);
-  const [claimSpId, setClaimSpId] = useState<string | null>(null);
   const { chain } = useNetwork();
 
   const controllerConnector = connector as unknown as ControllerConnector;
 
-  useEffect(() => {
-    if (!account) {
-      return;
+  const getDefaultStarterpackIds = () => {
+    if (chain && num.toHex(chain.id) === constants.StarknetChainId.SN_MAIN) {
+      return {
+        purchase: "sick-starterpack-mainnet",
+        claim: "claim-starterpack-mainnet",
+      };
     }
+    return {
+      purchase: "sick-starterpack-sepolia",
+      claim: "claim-starterpack-sepolia",
+    };
+  };
 
-    if (num.toHex(chain.id) === constants.StarknetChainId.SN_MAIN) {
-      setPurchaseSpId("sick-starterpack-mainnet");
-      setClaimSpId("claim-starterpack-mainnet");
-    } else {
-      setPurchaseSpId("sick-starterpack-sepolia");
-      setClaimSpId("claim-starterpack-sepolia");
-    }
-  }, [chain, account]);
+  const defaultIds = getDefaultStarterpackIds();
+  const [purchaseSpId, setPurchaseSpId] = useState<string>(defaultIds.purchase);
+  const [claimSpId, setClaimSpId] = useState<string>(defaultIds.claim);
 
-  if (!account || !purchaseSpId || !claimSpId) {
+  if (!account) {
     return null;
   }
 
@@ -90,40 +91,76 @@ export const Starterpack = () => {
   };
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-4">
       <h2>Starterpacks</h2>
-      <div className="flex flex-row gap-2">
-        <div className="flex items-center gap-2">
-          <Button
-            onClick={() => {
-              controllerConnector.controller.openStarterPack(purchaseSpId);
-            }}
-          >
-            Purchase Starterpack
-          </Button>
+
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <h3>Purchase Starterpack</h3>
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={purchaseSpId}
+              onChange={(e) => setPurchaseSpId(e.target.value)}
+              placeholder="Enter starterpack ID"
+              className="border rounded px-2 py-1 min-w-0 flex-1"
+            />
+            <Button
+              onClick={() => {
+                if (purchaseSpId.trim()) {
+                  controllerConnector.controller.openStarterPack(
+                    purchaseSpId.trim(),
+                  );
+                }
+              }}
+              disabled={!purchaseSpId.trim()}
+            >
+              Purchase Starterpack
+            </Button>
+          </div>
         </div>
-        <div className="flex items-center gap-2">
-          <Button
-            onClick={() => {
-              controllerConnector.controller.openStarterPack(claimSpId);
-            }}
-          >
-            Claim Starterpack
-          </Button>
+
+        <div className="flex flex-col gap-2">
+          <h3>Claim Starterpack</h3>
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={claimSpId}
+              onChange={(e) => setClaimSpId(e.target.value)}
+              placeholder="Enter starterpack ID"
+              className="border rounded px-2 py-1 min-w-0 flex-1"
+            />
+            <Button
+              onClick={() => {
+                if (claimSpId.trim()) {
+                  controllerConnector.controller.openStarterPack(
+                    claimSpId.trim(),
+                  );
+                }
+              }}
+              disabled={!claimSpId.trim()}
+            >
+              Claim Starterpack
+            </Button>
+          </div>
         </div>
-        <div className="flex items-center gap-2">
-          <Button
-            onClick={() => {
-              controllerConnector.controller.openStarterPack({
-                items: customStarterPack.items,
-                name: customStarterPack.name,
-                description: customStarterPack.description,
-                iconURL: customStarterPack.iconURL,
-              });
-            }}
-          >
-            Custom Warrior Pack ($110)
-          </Button>
+
+        <div className="flex flex-col gap-2">
+          <h3>Custom Starterpack</h3>
+          <div className="flex items-center gap-2">
+            <Button
+              onClick={() => {
+                controllerConnector.controller.openStarterPack({
+                  items: customStarterPack.items,
+                  name: customStarterPack.name,
+                  description: customStarterPack.description,
+                  iconURL: customStarterPack.iconURL,
+                });
+              }}
+            >
+              Custom Warrior Pack ($110)
+            </Button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Add support for specifying custom starterpack IDs in the example app for purchase and claim operations, while keeping the custom starterpack functionality unchanged.

## Changes Made

### Enhanced Starterpack Component
- **User-configurable input fields**: Replace hardcoded starterpack IDs with text inputs
- **Network-aware defaults**: Initialize inputs with appropriate default values based on current network (mainnet vs sepolia)
- **Preserved user input**: Remove useEffect dependency that would overwrite user-provided IDs during re-renders
- **Input validation**: Add button disable states for empty inputs with trim validation
- **Improved UX**: Organize interface into separate sections for Purchase, Claim, and Custom starterpacks

### Key Features
- **Purchase Starterpack**: Input field for custom starterpack ID with network-appropriate default
- **Claim Starterpack**: Input field for custom starterpack ID with network-appropriate default  
- **Custom Starterpack**: Unchanged functionality for custom starterpack definitions
- **Network Detection**: Automatically sets defaults based on StarkNet mainnet vs sepolia
- **Input Persistence**: User modifications are preserved without being overridden

### Technical Implementation
- Replaced `useEffect` with function-based initialization to prevent state overrides
- Added `getDefaultStarterpackIds()` helper for network-based default determination
- Enhanced UI with proper spacing, headings, and form validation
- Maintained existing custom starterpack functionality without changes

## Test plan
- [x] Verify input fields are pre-populated with network-appropriate defaults
- [x] Confirm user input is preserved during component re-renders
- [x] Test button disable states with empty inputs
- [x] Validate network switching updates default values correctly
- [x] Ensure custom starterpack functionality remains unchanged
- [x] Run linting and formatting checks

🤖 Generated with [Claude Code](https://claude.ai/code)