### PR TITLE
fix: remove cost component from starter pack claims

### DIFF
--- a/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
+++ b/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
@@ -152,13 +152,13 @@ export function StarterPackInner({
       <LayoutFooter>
         {error ? (
           <ErrorAlert title="Error" description={error.message} />
-        ) : (
+        ) : acquisitionType === StarterpackAcquisitionType.Paid ? (
           <CostBreakdown
             rails="stripe"
             costDetails={price}
             paymentUnit="usdc"
           />
-        )}
+        ) : null}
         <Button onClick={onProceed} disabled={!!error}>
           {acquisitionType === StarterpackAcquisitionType.Paid
             ? "Purchase"


### PR DESCRIPTION
## Summary
- Remove cost breakdown display from claimed (free) starter packs
- Cost component now only shows for paid starter packs

## Changes
Modified the `StarterPackInner` component in `/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx` to conditionally render the `CostBreakdown` component only when `acquisitionType === StarterpackAcquisitionType.Paid`.

Previously, the cost breakdown was displayed for all starter pack types, including free claims. This was confusing for users claiming free starter packs.

## Test plan
- [ ] Test claiming a free starter pack - should not show cost breakdown
- [ ] Test purchasing a paid starter pack - should show cost breakdown
- [ ] Verify UI layout remains consistent in both cases

🤖 Generated with [Claude Code](https://claude.ai/code)