### PR TITLE
fix: remove hover state from starter items and hide icon in header

### DIFF
--- a/packages/keychain/src/components/purchasenew/starterpack/starter-item.tsx
+++ b/packages/keychain/src/components/purchasenew/starterpack/starter-item.tsx
@@ -66,7 +66,7 @@ export const StarterItem = React.forwardRef<
           </div>
           <CardContent
             className={cn(
-              "bg-background-200 hover:bg-background-300 py-3 px-4 overflow-visible h-full rounded-lg flex flex-row items-center gap-3",
+              "bg-background-200 py-3 px-4 overflow-visible h-full rounded-lg flex flex-row items-center gap-3",
               className,
             )}
           >

--- a/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
+++ b/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
@@ -130,6 +130,7 @@ export function StarterPackInner({
           ) : undefined
         }
         right={supply ? <Supply amount={supply} /> : undefined}
+        hideIcon
       />
       <LayoutContent>
         <div className="flex flex-col gap-3">


### PR DESCRIPTION
## Summary
- Removed hover state from StarterItem component since items are not selectable
- Added hideIcon prop to HeaderInner in the starterpack page to hide the icon

## Test plan
- [ ] Verify starter pack items no longer show hover effect when mouse is over them
- [ ] Verify the HeaderInner in the starterpack page no longer displays an icon
- [ ] Test that the UI still looks correct without these elements

🤖 Generated with [Claude Code](https://claude.ai/code)