### PR TITLE
feat: support viewing inventory without connected controller

### DIFF
--- a/packages/keychain/src/components/inventory/collection/collection-asset.tsx
+++ b/packages/keychain/src/components/inventory/collection/collection-asset.tsx
@@ -39,20 +39,22 @@ import { useAccount } from "@/hooks/account";
 import { useConnection, useControllerTheme } from "@/hooks/connection";
 import { useNavigation } from "@/context/navigation";
 import { createExecuteUrl } from "@/utils/connection/execute";
+import { useViewerAddress } from "@/hooks/viewer";
 
 const OFFSET = 10;
 
 export function CollectionAsset() {
   const { chainId, project } = useConnection();
   const account = useAccount();
+  const { address: viewerAddress, isViewOnly } = useViewerAddress();
   const explorer = useExplorer();
-  const address = account?.address || "";
+  const address = viewerAddress || account?.address || "";
   const [searchParams, setSearchParams] = useSearchParams();
   const { navigate } = useNavigation();
   const [cap, setCap] = useState(OFFSET);
   const theme = useControllerTheme();
   const { editions } = useArcade();
-  const { tokens } = useTokens();
+  const { tokens } = useTokens(viewerAddress);
   const { provider, selfOrders, order, setAmount } = useMarketplace();
   const [loading, setLoading] = useState(false);
   const edition: EditionModel | undefined = useMemo(() => {
@@ -69,6 +71,7 @@ export function CollectionAsset() {
   } = useCollection({
     contractAddress: contractAddress,
     tokenIds: tokenId ? [tokenId] : [],
+    accountAddress: viewerAddress,
   });
 
   const { ownership, status: ownershipStatus } = useOwnership({
@@ -305,66 +308,68 @@ export function CollectionAsset() {
             </div>
           </LayoutContent>
 
-          <LayoutFooter
-            className={cn(
-              "relative flex flex-col items-center justify-center gap-y-4 bg-background-100 pt-0 select-none",
-              !isListed && !isOwner && "hidden",
-            )}
-          >
-            <div className="flex gap-3 w-full">
-              <Button
-                variant="secondary"
-                isLoading={loading}
-                onClick={handleUnlist}
-                className={cn(
-                  "w-full gap-2 text-destructive-100",
-                  (!isListed || !isOwner) && "hidden",
-                )}
-              >
-                <TagIcon variant="solid" size="sm" />
-                Unlist
-              </Button>
-              <Link
-                className={cn(
-                  "flex items-center justify-center gap-x-4 w-full",
-                  (isListed || !isOwner) && "hidden",
-                )}
-                to={`list?${searchParams.toString()}`}
-              >
-                <Button variant="secondary" className={cn("w-full gap-2")}>
-                  <TagIcon variant="solid" size="sm" />
-                  List
-                </Button>
-              </Link>
-              <Link
-                className={cn(
-                  "flex items-center justify-center gap-x-4 w-full",
-                  (!isListed || isOwner) && "hidden",
-                )}
-                to={`purchase?${searchParams.toString()}`}
-              >
+          {!isViewOnly && (
+            <LayoutFooter
+              className={cn(
+                "relative flex flex-col items-center justify-center gap-y-4 bg-background-100 pt-0 select-none",
+                !isListed && !isOwner && "hidden",
+              )}
+            >
+              <div className="flex gap-3 w-full">
                 <Button
+                  variant="secondary"
                   isLoading={loading}
-                  variant="primary"
-                  className="w-full gap-2"
+                  onClick={handleUnlist}
+                  className={cn(
+                    "w-full gap-2 text-destructive-100",
+                    (!isListed || !isOwner) && "hidden",
+                  )}
                 >
-                  Purchase
+                  <TagIcon variant="solid" size="sm" />
+                  Unlist
                 </Button>
-              </Link>
-              <Link
-                className={cn(
-                  "flex items-center justify-center gap-x-4 w-full",
-                  !isOwner && "hidden",
-                )}
-                to={`send?${searchParams.toString()}`}
-              >
-                <Button variant="secondary" className="w-full gap-2">
-                  <PaperPlaneIcon variant="solid" size="sm" />
-                  Send
-                </Button>
-              </Link>
-            </div>
-          </LayoutFooter>
+                <Link
+                  className={cn(
+                    "flex items-center justify-center gap-x-4 w-full",
+                    (isListed || !isOwner) && "hidden",
+                  )}
+                  to={`list?${searchParams.toString()}`}
+                >
+                  <Button variant="secondary" className={cn("w-full gap-2")}>
+                    <TagIcon variant="solid" size="sm" />
+                    List
+                  </Button>
+                </Link>
+                <Link
+                  className={cn(
+                    "flex items-center justify-center gap-x-4 w-full",
+                    (!isListed || isOwner) && "hidden",
+                  )}
+                  to={`purchase?${searchParams.toString()}`}
+                >
+                  <Button
+                    isLoading={loading}
+                    variant="primary"
+                    className="w-full gap-2"
+                  >
+                    Purchase
+                  </Button>
+                </Link>
+                <Link
+                  className={cn(
+                    "flex items-center justify-center gap-x-4 w-full",
+                    !isOwner && "hidden",
+                  )}
+                  to={`send?${searchParams.toString()}`}
+                >
+                  <Button variant="secondary" className="w-full gap-2">
+                    <PaperPlaneIcon variant="solid" size="sm" />
+                    Send
+                  </Button>
+                </Link>
+              </div>
+            </LayoutFooter>
+          )}
         </>
       )}
     </>

--- a/packages/keychain/src/components/inventory/collection/collections.tsx
+++ b/packages/keychain/src/components/inventory/collection/collections.tsx
@@ -7,13 +7,15 @@ import { useCollectibles } from "@/hooks/collectible";
 import { useArcade } from "@/hooks/arcade";
 import { useConnection, useControllerTheme } from "@/hooks/connection";
 import { EditionModel } from "@cartridge/arcade";
+import { useViewerAddress } from "@/hooks/viewer";
 
 import { getChecksumAddress } from "starknet";
 import { useMarketplace } from "@/hooks/marketplace";
 
 export function Collections() {
-  const { collections, status: CollectionsStatus } = useCollections();
-  const { collectibles, status: CollectiblesStatus } = useCollectibles();
+  const { address } = useViewerAddress();
+  const { collections, status: CollectionsStatus } = useCollections(address);
+  const { collectibles, status: CollectiblesStatus } = useCollectibles(address);
   const { editions } = useArcade();
   const { getCollectionOrders } = useMarketplace();
   const { project } = useConnection();

--- a/packages/keychain/src/hooks/collectible.ts
+++ b/packages/keychain/src/hooks/collectible.ts
@@ -144,9 +144,16 @@ export type CollectibleType = {
   count: number;
 };
 
-export function useCollectibles(): UseCollectiblesResponse {
+export function useCollectibles(
+  accountAddress?: string,
+): UseCollectiblesResponse {
   const account = useAccount();
-  const address = account?.address;
+  const connectedAddress = account?.address;
+  const { address: profileAddress } = useAccountProfile({ overridable: true });
+  const address = useMemo(
+    () => accountAddress ?? profileAddress ?? connectedAddress,
+    [accountAddress, profileAddress, connectedAddress],
+  );
   const { project } = useConnection();
   const [offset, setOffset] = useState(0);
   const [collectibles, setCollectibles] = useState<{

--- a/packages/keychain/src/hooks/collection.ts
+++ b/packages/keychain/src/hooks/collection.ts
@@ -114,12 +114,18 @@ async function fetchBalances(
 export function useCollection({
   contractAddress,
   tokenIds = [],
+  accountAddress,
 }: {
   contractAddress?: string;
   tokenIds?: string[];
+  accountAddress?: string;
 }): UseCollectionResponse {
-  const { address } = useAccountProfile({ overridable: true });
+  const { address: profileAddress } = useAccountProfile({ overridable: true });
   const { project } = useConnection();
+  const address = useMemo(
+    () => accountAddress ?? profileAddress,
+    [accountAddress, profileAddress],
+  );
 
   const [assets, setAssets] = useState<{ [key: string]: Asset }>({});
   const [collection, setCollection] = useState<Collection | undefined>(
@@ -249,9 +255,16 @@ export type CollectionType = {
   count: number;
 };
 
-export function useCollections(): UseCollectionsResponse {
+export function useCollections(
+  accountAddress?: string,
+): UseCollectionsResponse {
   const account = useAccount();
-  const address = account?.address;
+  const connectedAddress = account?.address;
+  const { address: profileAddress } = useAccountProfile({ overridable: true });
+  const address = useMemo(
+    () => accountAddress ?? profileAddress ?? connectedAddress,
+    [accountAddress, profileAddress, connectedAddress],
+  );
   const { project } = useConnection();
   const [collections, setCollections] = useState<{ [key: string]: Collection }>(
     {},

--- a/packages/keychain/src/hooks/viewer.ts
+++ b/packages/keychain/src/hooks/viewer.ts
@@ -1,0 +1,45 @@
+import { useMemo } from "react";
+import { useAccount, useAccountProfile } from "./account";
+import { useConnection } from "./connection";
+
+export type UseViewerAddressResponse = {
+  address: string | undefined;
+  isViewOnly: boolean;
+  hasController: boolean;
+};
+
+/**
+ * Hook to get the viewer address for inventory/collectibles
+ * Returns controller address if connected, otherwise falls back to URL path address
+ */
+export function useViewerAddress(): UseViewerAddressResponse {
+  const { controller } = useConnection();
+  const connectedAccount = useAccount();
+  const profileAccount = useAccountProfile({ overridable: true });
+
+  const hasController = useMemo(() => {
+    return !!controller && !!connectedAccount?.address;
+  }, [controller, connectedAccount]);
+
+  const address = useMemo(() => {
+    // Use connected account if available
+    if (connectedAccount?.address) {
+      return connectedAccount.address;
+    }
+    // Fall back to profile address from URL
+    return profileAccount.address;
+  }, [connectedAccount, profileAccount]);
+
+  const isViewOnly = useMemo(() => {
+    // View only if no controller connected OR if viewing another account
+    if (!hasController) return true;
+    if (!profileAccount.address) return false;
+    return connectedAccount?.address !== profileAccount.address;
+  }, [hasController, connectedAccount, profileAccount]);
+
+  return {
+    address,
+    isViewOnly,
+    hasController,
+  };
+}


### PR DESCRIPTION
## Summary
- Enable users to view collectibles and inventory without a connected controller
- Use owner address from URL path for data fetching in view-only mode
- Hide action buttons when controller is not connected

## Changes
- **New `useViewerAddress` hook**: Resolves viewer address from connected controller or URL path
- **Updated data hooks**: Collection/collectible hooks now accept optional `accountAddress` parameter
- **View-only UI updates**: Hide Send/List/Purchase buttons and disable selection when no controller
- **Backward compatibility**: All existing functionality preserved for connected users

## Test Plan
- [ ] Navigate to `/account/[username]/inventory` without connected controller
- [ ] Verify inventory items are displayed correctly
- [ ] Confirm all action buttons are hidden in view-only mode
- [ ] Connect controller and verify all actions become available
- [ ] Test viewing another user's inventory while connected
- [ ] Verify selection functionality is disabled in view-only mode

This enables read-only access to inventory pages for users browsing without authentication while preserving all interactive features for connected users.

🤖 Generated with [Claude Code](https://claude.ai/code)