### PR TITLE
fix: external wallet available check

### DIFF
--- a/packages/controller/src/wallets/bridge.ts
+++ b/packages/controller/src/wallets/bridge.ts
@@ -23,22 +23,22 @@ export class WalletBridge {
     }
 
     const metamask = new MetaMaskWallet();
-    metamask.isAvailable() && this.walletAdapters.set("metamask", metamask);
+    this.walletAdapters.set("metamask", metamask);
 
     const phantom = new PhantomWallet();
-    phantom.isAvailable() && this.walletAdapters.set("phantom", phantom);
+    this.walletAdapters.set("phantom", phantom);
 
     const argent = new ArgentWallet();
-    argent.isAvailable() && this.walletAdapters.set("argent", argent);
+    this.walletAdapters.set("argent", argent);
 
     const braavos = new BraavosWallet();
-    braavos.isAvailable() && this.walletAdapters.set("braavos", braavos);
+    this.walletAdapters.set("braavos", braavos);
 
     const rabby = new RabbyWallet();
-    rabby.isAvailable() && this.walletAdapters.set("rabby", rabby);
+    this.walletAdapters.set("rabby", rabby);
 
     const base = new BaseWallet();
-    base.isAvailable() && this.walletAdapters.set("base", base);
+    this.walletAdapters.set("base", base);
 
     window.wallet_bridge = this;
   }


### PR DESCRIPTION
This fixes an issue where sometimes starknet window objects are not immediately available on init so we never add them to walletAdapters, results in never being able to detect starknet wallets. Now `detectWallet` should return realtime availability on all wallets

