### PR TITLE
fix: hide USDC payment type box on Starter Pack page

### DIFF
--- a/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
+++ b/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
@@ -153,11 +153,7 @@ export function StarterPackInner({
         {error ? (
           <ErrorAlert title="Error" description={error.message} />
         ) : acquisitionType === StarterpackAcquisitionType.Paid ? (
-          <CostBreakdown
-            rails="stripe"
-            costDetails={price}
-            paymentUnit="usdc"
-          />
+          <CostBreakdown rails="stripe" costDetails={price} />
         ) : null}
         <Button onClick={onProceed} disabled={!!error}>
           {acquisitionType === StarterpackAcquisitionType.Paid


### PR DESCRIPTION
## Summary
- Removed the USDC payment type indicator box from the Starter Pack page's cost breakdown
- The total cost is still displayed correctly, just without the redundant USDC denomination badge

## Test plan
- [ ] Navigate to a Starter Pack page with paid acquisition type
- [ ] Verify that the cost breakdown shows the total price without the USDC box on the right
- [ ] Verify that other pages still show payment type indicators when needed

🤖 Generated with [Claude Code](https://claude.ai/code)