### PR TITLE
fix: avoid having eth wallets on mobile browsers

### DIFF
--- a/packages/controller/src/utils.ts
+++ b/packages/controller/src/utils.ts
@@ -1,3 +1,6 @@
+import { Policy } from "@cartridge/controller-wasm/controller";
+import { Policies, SessionPolicies } from "@cartridge/presets";
+import { ChainId } from "@starknet-io/types-js";
 import {
   addAddressPadding,
   Call,
@@ -9,9 +12,6 @@ import {
   typedData,
   TypedDataRevision,
 } from "starknet";
-import { Policy } from "@cartridge/controller-wasm/controller";
-import { Policies, SessionPolicies } from "@cartridge/presets";
-import { ChainId } from "@starknet-io/types-js";
 import { ParsedSessionPolicies } from "./policies";
 
 // Whitelist of allowed property names to prevent prototype pollution
@@ -205,4 +205,12 @@ export function parseChainId(url: URL): ChainId {
   }
 
   throw new Error(`Chain ${url.toString()} not supported`);
+}
+
+export function isMobile() {
+  return (
+    window.matchMedia("(max-width: 768px)").matches ||
+    "ontouchstart" in window ||
+    navigator.maxTouchPoints > 0
+  );
 }

--- a/packages/controller/src/wallets/ethereum-base.ts
+++ b/packages/controller/src/wallets/ethereum-base.ts
@@ -1,5 +1,7 @@
 import { getAddress } from "ethers/address";
 import { createStore, EIP6963ProviderDetail } from "mipd";
+import { isMobile } from "../utils";
+import { chainIdToPlatform } from "./platform";
 import {
   ExternalPlatform,
   ExternalWallet,
@@ -7,7 +9,6 @@ import {
   ExternalWalletType,
   WalletAdapter,
 } from "./types";
-import { chainIdToPlatform } from "./platform";
 
 export abstract class EthereumWalletBase implements WalletAdapter {
   abstract readonly type: ExternalWalletType;
@@ -100,6 +101,10 @@ export abstract class EthereumWalletBase implements WalletAdapter {
   }
 
   isAvailable(): boolean {
+    if (isMobile()) {
+      return false;
+    }
+
     // Check dynamically each time, as the provider might be announced after instantiation
     const provider = this.getProvider();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Disables Ethereum wallets on mobile by adding `isMobile()` utility and gating `EthereumWalletBase.isAvailable()` behind a desktop-only check.
> 
> - **Wallets (Ethereum)**:
>   - Gate `EthereumWalletBase.isAvailable()` to return `false` on mobile using `isMobile()`.
> - **Utils**:
>   - Add `isMobile()` helper in `packages/controller/src/utils.ts` for basic touch/screen-width detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39e2a45cede6130e9a8fd6ed69eab1a4d7bb61c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->