### PR TITLE
fix: resolve circular dependency and BigInt handling in starterpack

### DIFF
--- a/packages/keychain/src/components/purchasenew/starterpack/starterpack.stories.tsx
+++ b/packages/keychain/src/components/purchasenew/starterpack/starterpack.stories.tsx
@@ -6,6 +6,11 @@ import { StarterPackItemType } from "@cartridge/controller";
 
 const meta = {
   component: StarterPackInner,
+  argTypes: {
+    starterpackItems: {
+      control: false, // Disable controls for BigInt serialization
+    },
+  },
   decorators: [
     (Story) => (
       <NavigationProvider>
@@ -22,7 +27,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     name: "Starterpack",
-    supply: 10,
     acquisitionType: StarterpackAcquisitionType.Paid,
     starterpackItems: [
       {
@@ -31,7 +35,26 @@ export const Default: Story = {
         iconURL:
           "https://fastly.picsum.photos/id/641/200/200.jpg?hmac=9pd71nRRRsT7TXf0zn0hQ6tW6VQnQ-UtL1JXDhJZB8E",
         type: StarterPackItemType.NONFUNGIBLE,
-        price: 100n,
+        price: 5000000n,
+      },
+    ],
+  },
+};
+
+export const StarterPackWithNoSupply: Story = {
+  args: {
+    name: "Starterpack",
+    supply: 0,
+    acquisitionType: StarterpackAcquisitionType.Paid,
+    isVerified: false,
+    starterpackItems: [
+      {
+        name: "Starter NFT",
+        description: "A unique starter NFT for your collection",
+        iconURL:
+          "https://fastly.picsum.photos/id/641/200/200.jpg?hmac=9pd71nRRRsT7TXf0zn0hQ6tW6VQnQ-UtL1JXDhJZB8E",
+        type: StarterPackItemType.NONFUNGIBLE,
+        price: 5000000n,
       },
     ],
   },
@@ -40,7 +63,6 @@ export const Default: Story = {
 export const StarterPackWithCollections: Story = {
   args: {
     name: "Starterpack",
-    supply: 10,
     acquisitionType: StarterpackAcquisitionType.Claimed,
     starterpackItems: [
       {
@@ -49,7 +71,6 @@ export const StarterPackWithCollections: Story = {
         iconURL:
           "https://fastly.picsum.photos/id/641/200/200.jpg?hmac=9pd71nRRRsT7TXf0zn0hQ6tW6VQnQ-UtL1JXDhJZB8E",
         type: StarterPackItemType.NONFUNGIBLE,
-        price: 0n,
       },
     ],
   },
@@ -58,7 +79,6 @@ export const StarterPackWithCollections: Story = {
 export const StarterPackWithVerifiedEdition: Story = {
   args: {
     name: "Starterpack",
-    supply: 10,
     acquisitionType: StarterpackAcquisitionType.Claimed,
     edition: "Season 0: Genesis",
     isVerified: true,
@@ -69,7 +89,6 @@ export const StarterPackWithVerifiedEdition: Story = {
         iconURL:
           "https://fastly.picsum.photos/id/641/200/200.jpg?hmac=9pd71nRRRsT7TXf0zn0hQ6tW6VQnQ-UtL1JXDhJZB8E",
         type: StarterPackItemType.NONFUNGIBLE,
-        price: 0n,
       },
     ],
   },
@@ -78,7 +97,6 @@ export const StarterPackWithVerifiedEdition: Story = {
 export const StarterPackWithUnverifiedEdition: Story = {
   args: {
     name: "Starterpack",
-    supply: 10,
     acquisitionType: StarterpackAcquisitionType.Claimed,
     edition: "Season 0: Genesis",
     isVerified: false,
@@ -89,8 +107,8 @@ export const StarterPackWithUnverifiedEdition: Story = {
         iconURL:
           "https://fastly.picsum.photos/id/641/200/200.jpg?hmac=9pd71nRRRsT7TXf0zn0hQ6tW6VQnQ-UtL1JXDhJZB8E",
         type: StarterPackItemType.NONFUNGIBLE,
-        price: 0n,
       },
     ],
   },
 };
+

--- a/packages/keychain/src/components/purchasenew/starterpack/starterpack.stories.tsx
+++ b/packages/keychain/src/components/purchasenew/starterpack/starterpack.stories.tsx
@@ -111,4 +111,3 @@ export const StarterPackWithUnverifiedEdition: Story = {
     ],
   },
 };
-

--- a/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
+++ b/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
@@ -24,10 +24,10 @@ import { Supply } from "./supply";
 import { useEffect, useMemo } from "react";
 import { LoadingState } from "../loading";
 import { CostBreakdown } from "../review/cost";
-import { PricingDetails } from "@/components/purchase/types";
 import { decodeStarterPack } from "@/utils/starterpack-url";
 import { usdcToUsd } from "@/utils/starterpack";
 import { useConnection } from "@/hooks/connection";
+import { CostDetails } from "../types";
 
 export function PurchaseStarterpack() {
   const { starterpackId } = useParams();
@@ -116,16 +116,17 @@ export function StarterPackInner({
   };
 
   const price = useMemo(() => {
-    const total = starterpackItems.reduce(
-      (acc, item) => acc + usdcToUsd(item.price || 0n),
-      0,
+    const totalUsdc = starterpackItems.reduce(
+      (acc, item) => acc + (item.price || 0n),
+      0n,
     );
+    const total = usdcToUsd(totalUsdc);
 
     return {
       baseCostInCents: total * 100,
       processingFeeInCents: 0,
       totalInCents: total * 100,
-    } satisfies PricingDetails;
+    } as CostDetails;
   }, [starterpackItems]);
 
   return (
@@ -140,7 +141,7 @@ export function StarterPackInner({
             </span>
           ) : undefined
         }
-        right={supply ? <Supply amount={supply} /> : undefined}
+        right={supply !== undefined ? <Supply amount={supply} /> : undefined}
         hideIcon
       />
       <LayoutContent>
@@ -167,7 +168,7 @@ export function StarterPackInner({
         ) : acquisitionType === StarterpackAcquisitionType.Paid ? (
           <CostBreakdown rails="stripe" costDetails={price} />
         ) : null}
-        <Button onClick={onProceed} disabled={!!error}>
+        <Button onClick={onProceed} disabled={!!error || supply === 0}>
           {acquisitionType === StarterpackAcquisitionType.Paid
             ? "Purchase"
             : "Check Eligibility"}

--- a/packages/keychain/src/hooks/starterpack.ts
+++ b/packages/keychain/src/hooks/starterpack.ts
@@ -18,12 +18,11 @@ import {
   StarterPackItem,
   StarterPackItemType,
 } from "@cartridge/controller";
-import { ItemType } from "@/context/purchase";
 
 export const enum StarterItemType {
-  NFT = ItemType.NFT,
-  CREDIT = ItemType.CREDIT,
-  ERC20 = ItemType.ERC20,
+  NFT = "NFT",
+  CREDIT = "CREDIT",
+  ERC20 = "ERC20",
 }
 
 export interface StarterItemData {


### PR DESCRIPTION
- Remove circular dependency between starterpack hook and purchase context by using string literals in StarterItemType enum instead of referencing ItemType
- Fix price calculation to sum BigInt values before converting to USD
- Disable Storybook controls for starterpackItems to prevent BigInt serialization errors
- Add price values to starterpack story examples

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch StarterItemType to string literals to break a circular dependency, fix price calc by summing BigInt USDC before USD conversion, tighten supply UI/CTA logic, and update Storybook stories/controls.
> 
> - **Starterpack UI/logic**:
>   - Correct price calculation: sum `BigInt` USDC across `starterpackItems` then convert via `usdcToUsd`; update type to `CostDetails`.
>   - Supply handling: show `Supply` when defined (including 0) and disable action button when `supply === 0`.
> - **Hooks**:
>   - Replace `StarterItemType` enum values with string literals (`"NFT" | "CREDIT" | "ERC20"`) to remove dependency on `ItemType`.
> - **Storybook**:
>   - Disable controls for `starterpackItems` to avoid `BigInt` serialization issues.
>   - Update stories: increase example `price` to `5000000n`, add `StarterPackWithNoSupply` (supply 0), and adjust sample props (e.g., removed some `supply`/`price` fields).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27ceb4ab654c7204893a1d7e1b42403b482082ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->