### PR TITLE
fix: disable keychain scrollbar globally

### DIFF
--- a/packages/keychain/src/index.css
+++ b/packages/keychain/src/index.css
@@ -16,4 +16,24 @@
   * {
     @apply focus:outline-none focus:ring-0;
   }
+
+  /* Hide scrollbars globally while preserving scroll functionality */
+  ::-webkit-scrollbar {
+    width: 0px;
+    background: transparent;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: transparent;
+  }
+
+  html {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+
+  body {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
 }


### PR DESCRIPTION
This pull request makes a global CSS update to hide scrollbars throughout the application while maintaining scroll functionality. This change improves the visual appearance by removing scrollbars from all elements, including the `html` and `body`, without affecting usability.

Visual styling:

* Added global CSS rules to hide scrollbars for all elements using `::-webkit-scrollbar`, `::-webkit-scrollbar-thumb`, and by setting `-ms-overflow-style` and `scrollbar-width` to `none` on `html` and `body`.