### PR TITLE
fix: update preset and fix non balance img

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@cartridge/presets": "github:cartridge-gg/presets#90a5fe0",
+    "@cartridge/presets": "github:cartridge-gg/presets#0697bf3",
     "@cartridge/ui": "github:cartridge-gg/ui#2313a28",
     "tailwindcss": "catalog:"
   },

--- a/packages/keychain/src/hooks/token.ts
+++ b/packages/keychain/src/hooks/token.ts
@@ -309,6 +309,11 @@ export function useTokens(accountAddress?: string): UseTokensResponse {
         (v) => BigInt(v?.address || "0x0") === BigInt(contractAddress),
       );
       const change = value ? value.current.value - value.period.value : 0;
+      const image = erc20Metadata.find(
+        (m) =>
+          getChecksumAddress(m.l2_token_address) ===
+          getChecksumAddress(contractAddress),
+      )?.logo_url;
       tokenMap[normalizedAddress] = {
         balance: {
           amount: Number(token.balance.value) / 10 ** token.meta.decimals,
@@ -320,7 +325,7 @@ export function useTokens(accountAddress?: string): UseTokensResponse {
           symbol: token.meta.symbol,
           decimals: token.meta.decimals,
           address: getChecksumAddress(contractAddress),
-          image: token.meta.logoUrl,
+          image: token.meta.logoUrl || image,
         },
       };
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,8 +162,8 @@ importers:
   .:
     dependencies:
       '@cartridge/presets':
-        specifier: github:cartridge-gg/presets#90a5fe0
-        version: https://codeload.github.com/cartridge-gg/presets/tar.gz/90a5fe0
+        specifier: github:cartridge-gg/presets#0697bf3
+        version: https://codeload.github.com/cartridge-gg/presets/tar.gz/0697bf3
       '@cartridge/ui':
         specifier: github:cartridge-gg/ui#2313a28
         version: https://codeload.github.com/cartridge-gg/ui/tar.gz/2313a28(@types/react-dom@18.3.7(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sonner@1.7.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(starknet@8.5.4)(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/node@16.18.11)(typescript@5.8.3)))(viem@2.36.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.4))
@@ -984,8 +984,8 @@ packages:
   '@cartridge/penpal@6.2.4':
     resolution: {integrity: sha512-tdpOnSJJBFMlgLZ1+z9Ho5e6cG5EgMAb1Cmmh1lGT2tmplogU/XPMjLE6CwvKAPDoe6a38iMnbH+ySTAWWIOKA==}
 
-  '@cartridge/presets@https://codeload.github.com/cartridge-gg/presets/tar.gz/90a5fe0':
-    resolution: {tarball: https://codeload.github.com/cartridge-gg/presets/tar.gz/90a5fe0}
+  '@cartridge/presets@https://codeload.github.com/cartridge-gg/presets/tar.gz/0697bf3':
+    resolution: {tarball: https://codeload.github.com/cartridge-gg/presets/tar.gz/0697bf3}
     version: 0.0.1
 
   '@cartridge/presets@https://codeload.github.com/cartridge-gg/presets/tar.gz/e6a5022':
@@ -6040,6 +6040,7 @@ packages:
 
   get-starknet-core@4.0.0:
     resolution: {integrity: sha512-6pLmidQZkC3wZsrHY99grQHoGpuuXqkbSP65F8ov1/JsEI8DDLkhsAuLCKFzNOK56cJp+f1bWWfTJ57e9r5eqQ==}
+    deprecated: Package no longer supported. Please use @starknet-io/get-starknet-core
 
   get-stdin@5.0.1:
     resolution: {integrity: sha512-jZV7n6jGE3Gt7fgSTJoz91Ak5MuTLwMwkoYdjxuJ/AmjIsE1UC03y/IWkZCQGEvVNS9qoRNwy5BCqxImv0FVeA==}
@@ -10001,7 +10002,7 @@ snapshots:
 
   '@cartridge/penpal@6.2.4': {}
 
-  '@cartridge/presets@https://codeload.github.com/cartridge-gg/presets/tar.gz/90a5fe0':
+  '@cartridge/presets@https://codeload.github.com/cartridge-gg/presets/tar.gz/0697bf3':
     dependencies:
       '@starknet-io/types-js': 0.8.4
 
@@ -13325,7 +13326,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 22.15.3
 
   '@types/cookie@0.6.0': {}
 
@@ -13396,6 +13397,7 @@ snapshots:
   '@types/node@24.5.2':
     dependencies:
       undici-types: 7.12.0
+    optional: true
 
   '@types/parse-json@4.0.2': {}
 
@@ -13440,11 +13442,11 @@ snapshots:
 
   '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 22.15.3
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 24.5.2
+      '@types/node': 22.15.3
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -20310,7 +20312,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.12.0: {}
+  undici-types@7.12.0:
+    optional: true
 
   undici@5.28.4:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Use preset metadata as a fallback for ERC20 token images when missing, and update @cartridge/presets commit.
> 
> - **Keychain**:
>   - **Token images**: In `packages/keychain/src/hooks/token.ts`, when building RPC token metadata, look up `erc20Metadata` and fallback to its `logo_url` if `token.meta.logoUrl` is missing.
> - **Dependencies**:
>   - Update `@cartridge/presets` to `github:cartridge-gg/presets#0697bf3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73846a59f904b752930f61bf65cf32300d798db9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->