### PR TITLE
fix: remove Solana from payment options

### DIFF
--- a/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
+++ b/packages/keychain/src/components/purchasenew/starterpack/starterpack.tsx
@@ -101,7 +101,7 @@ export function StarterPackInner({
     switch (acquisitionType) {
       case StarterpackAcquisitionType.Paid: {
         const methods = isMainnet
-          ? "ethereum;solana;base;arbitrum;optimism"
+          ? "ethereum;base;arbitrum;optimism"
           : "arbitrum";
 
         navigate(`/purchase/method/${methods}`);


### PR DESCRIPTION
Removed Solana from the payment methods list in starterpack purchase flow to temporarily disable Solana payments until transaction issues are resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes Solana from the mainnet payment methods list in the starterpack purchase flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7b6803718b6d79ea0d83e016b6361500662367e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->