### PR TITLE
fix: add padding to token send footer

### DIFF
--- a/packages/keychain/src/components/inventory/token/token.tsx
+++ b/packages/keychain/src/components/inventory/token/token.tsx
@@ -226,7 +226,7 @@ function ERC20() {
       </LayoutContent>
 
       {compatibility && controller && (
-        <LayoutFooter>
+        <LayoutFooter className="p-4">
           <Link to={`send?${searchParams.toString()}`} className="w-full">
             <Button className="w-full space-x-2">
               <PaperPlaneIcon variant="solid" />


### PR DESCRIPTION
Linear ticket: https://linear.app/cartridge/issue/C7E-955/add-padding-top-to-the-controller-button-bar

This pull request makes a small UI adjustment to the `ERC20` component in `token.tsx`. The change adds padding to the `LayoutFooter` element to improve spacing.