### PR TITLE
Clean up the Connector package

### DIFF
--- a/packages/connector/package.json
+++ b/packages/connector/package.json
@@ -15,8 +15,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./controller": "./dist/controller.js",
-    "./session": "./dist/session.js",
-    "./telegram": "./dist/telegram.js"
+    "./session": "./dist/session.js"
   },
   "typesVersions": {
     "*": {
@@ -25,9 +24,6 @@
       ],
       "session": [
         "./dist/session.d.ts"
-      ],
-      "telegram": [
-        "./dist/telegram.d.ts"
       ]
     }
   },

--- a/packages/connector/src/index.ts
+++ b/packages/connector/src/index.ts
@@ -1,1 +1,2 @@
 export { default as ControllerConnector } from "./controller";
+export { default as SessionConnector } from "./session";


### PR DESCRIPTION
This PR removes outdated references to a Telegram connector, as well as exports the SessionConnector through `index.ts`, enabling the following import syntax:

```
import { SessionConnector } from @cartridge/connector
```